### PR TITLE
Add bindings for password functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ save_deps: &SAVE_DEPS
       - ~/.cargo/registry/cache
 
 stable: &STABLE
-  RUST_VERSION: "1.20.0"
+  RUST_VERSION: "1.26.2"
 
 nightly: &NIGHTLY
   RUST_VERSION: nightly

--- a/security-framework-sys/Cargo.toml
+++ b/security-framework-sys/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
+MacTypes-sys = "1.1.0"
 core-foundation-sys = "0.5.1"
 
 [features]

--- a/security-framework-sys/src/base.rs
+++ b/security-framework-sys/src/base.rs
@@ -1,12 +1,30 @@
 use core_foundation_sys::base::OSStatus;
 use core_foundation_sys::string::CFStringRef;
 use libc::c_void;
+use MacTypes_sys::OSType;
 
 pub enum OpaqueSecKeychainRef {}
 pub type SecKeychainRef = *mut OpaqueSecKeychainRef;
 
 pub enum OpaqueSecKeychainItemRef {}
 pub type SecKeychainItemRef = *mut OpaqueSecKeychainItemRef;
+
+pub type SecKeychainAttrType = OSType;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SecKeychainAttribute {
+    pub tag: SecKeychainAttrType,
+    pub length: u32,
+    pub data: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SecKeychainAttributeList {
+    pub count: u32,
+    pub attr: *mut SecKeychainAttribute,
+}
 
 pub enum OpaqueSecCertificateRef {}
 pub type SecCertificateRef = *mut OpaqueSecCertificateRef;

--- a/security-framework-sys/src/keychain.rs
+++ b/security-framework-sys/src/keychain.rs
@@ -1,7 +1,7 @@
-use core_foundation_sys::base::{Boolean, CFTypeID, OSStatus};
+use core_foundation_sys::base::{Boolean, CFTypeID, CFTypeRef, OSStatus};
 use libc::{c_char, c_uint, c_void};
 
-use base::{SecAccessRef, SecKeychainRef};
+use base::{SecAccessRef, SecKeychainItemRef, SecKeychainRef};
 
 pub const SEC_KEYCHAIN_SETTINGS_VERS1: c_uint = 1;
 
@@ -11,6 +11,75 @@ pub struct SecKeychainSettings {
     pub lockOnSleep: Boolean,
     pub useLockInterval: Boolean,
     pub lockInterval: c_uint,
+}
+
+/// Like Apple's headers, it assumes Little Endian,
+/// as there are no supported Big Endian machines any more :(
+macro_rules! char_lit {
+    ($e:expr) => {
+        ($e[3] as u32) + (($e[2] as u32) << 8) + (($e[1] as u32) << 16) + (($e[0] as u32) << 24)
+    };
+}
+
+macro_rules! char_lit_swapped {
+    ($e:expr) => {
+        ($e[0] as u32) + (($e[1] as u32) << 8) + (($e[2] as u32) << 16) + (($e[3] as u32) << 24)
+    };
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SecProtocolType {
+    FTP = char_lit!(b"ftp "),
+    FTPAccount = char_lit!(b"ftpa"),
+    HTTP = char_lit!(b"http"),
+    IRC = char_lit!(b"irc "),
+    NNTP = char_lit!(b"nntp"),
+    POP3 = char_lit!(b"pop3"),
+    SMTP = char_lit!(b"smtp"),
+    SOCKS = char_lit!(b"sox "),
+    IMAP = char_lit!(b"imap"),
+    LDAP = char_lit!(b"ldap"),
+    AppleTalk = char_lit!(b"atlk"),
+    AFP = char_lit!(b"afp "),
+    Telnet = char_lit!(b"teln"),
+    SSH = char_lit!(b"ssh "),
+    FTPS = char_lit!(b"ftps"),
+    HTTPS = char_lit!(b"htps"),
+    HTTPProxy = char_lit!(b"htpx"),
+    HTTPSProxy = char_lit!(b"htsx"),
+    FTPProxy = char_lit!(b"ftpx"),
+    CIFS = char_lit!(b"cifs"),
+    SMB = char_lit!(b"smb "),
+    RTSP = char_lit!(b"rtsp"),
+    RTSPProxy = char_lit!(b"rtsx"),
+    DAAP = char_lit!(b"daap"),
+    EPPC = char_lit!(b"eppc"),
+    IPP = char_lit!(b"ipp "),
+    NNTPS = char_lit!(b"ntps"),
+    LDAPS = char_lit!(b"ldps"),
+    TelnetS = char_lit!(b"tels"),
+    IMAPS = char_lit!(b"imps"),
+    IRCS = char_lit!(b"ircs"),
+    POP3S = char_lit!(b"pops"),
+    CVSpserver = char_lit!(b"cvsp"),
+    SVN = char_lit!(b"svn "),
+    Any = 0,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SecAuthenticationType {
+    // [sic] Apple has got two related enums each with a different endianness!
+    NTLM = char_lit_swapped!(b"ntlm"),
+    MSN = char_lit_swapped!(b"msna"),
+    DPA = char_lit_swapped!(b"dpaa"),
+    RPA = char_lit_swapped!(b"rpaa"),
+    HTTPBasic = char_lit_swapped!(b"http"),
+    HTTPDigest = char_lit_swapped!(b"httd"),
+    HTMLForm = char_lit_swapped!(b"form"),
+    Default = char_lit_swapped!(b"dflt"),
+    Any = 0,
 }
 
 extern "C" {
@@ -31,6 +100,68 @@ extern "C" {
         password: *const c_void,
         usePassword: Boolean,
     ) -> OSStatus;
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainFindGenericPassword(
+        keychainOrArray: CFTypeRef,
+        serviceNameLength: u32,
+        serviceName: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        passwordLength: *mut u32,
+        passwordData: *mut *mut c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainFindInternetPassword(
+        keychainOrArray: CFTypeRef,
+        serverNameLength: u32,
+        serverName: *const c_char,
+        securityDomainLength: u32,
+        securityDomain: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        pathLength: u32,
+        path: *const c_char,
+        port: u16,
+        protocol: SecProtocolType,
+        authenticationType: SecAuthenticationType,
+        passwordLength: *mut u32,
+        passwordData: *mut *mut c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainAddGenericPassword(
+        keychain: SecKeychainRef,
+        serviceNameLength: u32,
+        serviceName: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        passwordLength: u32,
+        passwordData: *const c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainAddInternetPassword(
+        keychain: SecKeychainRef,
+        serverNameLength: u32,
+        serverName: *const c_char,
+        securityDomainLength: u32,
+        securityDomain: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        pathLength: u32,
+        path: *const c_char,
+        port: u16,
+        protocol: SecProtocolType,
+        authenticationType: SecAuthenticationType,
+        passwordLength: u32,
+        passwordData: *const c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
     pub fn SecKeychainSetSettings(
         keychain: SecKeychainRef,
         newSettings: *const SecKeychainSettings,

--- a/security-framework-sys/src/keychain_item.rs
+++ b/security-framework-sys/src/keychain_item.rs
@@ -1,5 +1,24 @@
-use core_foundation_sys::base::CFTypeID;
+use base::{SecKeychainAttributeList, SecKeychainItemRef};
+use core_foundation_sys::base::{CFTypeID, OSStatus};
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use libc::c_void;
 
 extern "C" {
     pub fn SecKeychainItemGetTypeID() -> CFTypeID;
+
+    pub fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) -> OSStatus;
+
+    pub fn SecItemUpdate(query: CFDictionaryRef, attributesToUpdate: CFDictionaryRef) -> OSStatus;
+
+    pub fn SecKeychainItemModifyAttributesAndData(
+        itemRef: SecKeychainItemRef,
+        attrList: *const SecKeychainAttributeList,
+        length: u32,
+        data: *const c_void,
+    ) -> OSStatus;
+
+    pub fn SecKeychainItemFreeContent(
+        attrList: *mut SecKeychainAttributeList,
+        data: *mut c_void,
+    ) -> OSStatus;
 }

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://sfackler.github.io/rust-security-framework/doc/v0.2")]
 #![allow(bad_style)]
 
+extern crate MacTypes_sys;
 extern crate core_foundation_sys;
 extern crate libc;
 


### PR DESCRIPTION
The higher-level wrapper for passwords could be more ergonomic, so I've removed it from the PR. This is just the uncontroversial `-sys` bindings part.
