### PR TITLE
Higher-level wrapper for passwords

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ save_deps: &SAVE_DEPS
       - ~/.cargo/registry/cache
 
 stable: &STABLE
-  RUST_VERSION: "1.20.0"
+  RUST_VERSION: "1.26.2"
 
 nightly: &NIGHTLY
   RUST_VERSION: nightly

--- a/security-framework-sys/Cargo.toml
+++ b/security-framework-sys/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
+MacTypes-sys = "1.1.0"
 core-foundation-sys = "0.5.1"
 
 [features]

--- a/security-framework-sys/src/base.rs
+++ b/security-framework-sys/src/base.rs
@@ -1,12 +1,30 @@
 use core_foundation_sys::base::OSStatus;
 use core_foundation_sys::string::CFStringRef;
 use libc::c_void;
+use MacTypes_sys::OSType;
 
 pub enum OpaqueSecKeychainRef {}
 pub type SecKeychainRef = *mut OpaqueSecKeychainRef;
 
 pub enum OpaqueSecKeychainItemRef {}
 pub type SecKeychainItemRef = *mut OpaqueSecKeychainItemRef;
+
+pub type SecKeychainAttrType = OSType;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SecKeychainAttribute {
+    pub tag: SecKeychainAttrType,
+    pub length: u32,
+    pub data: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct SecKeychainAttributeList {
+    pub count: u32,
+    pub attr: *mut SecKeychainAttribute,
+}
 
 pub enum OpaqueSecCertificateRef {}
 pub type SecCertificateRef = *mut OpaqueSecCertificateRef;

--- a/security-framework-sys/src/keychain.rs
+++ b/security-framework-sys/src/keychain.rs
@@ -1,7 +1,7 @@
-use core_foundation_sys::base::{Boolean, CFTypeID, OSStatus};
+use core_foundation_sys::base::{Boolean, CFTypeID, CFTypeRef, OSStatus};
 use libc::{c_char, c_uint, c_void};
 
-use base::{SecAccessRef, SecKeychainRef};
+use base::{SecAccessRef, SecKeychainItemRef, SecKeychainRef};
 
 pub const SEC_KEYCHAIN_SETTINGS_VERS1: c_uint = 1;
 
@@ -11,6 +11,75 @@ pub struct SecKeychainSettings {
     pub lockOnSleep: Boolean,
     pub useLockInterval: Boolean,
     pub lockInterval: c_uint,
+}
+
+/// Like Apple's headers, it assumes Little Endian,
+/// as there are no supported Big Endian machines any more :(
+macro_rules! char_lit {
+    ($e:expr) => {
+        ($e[3] as u32) + (($e[2] as u32) << 8) + (($e[1] as u32) << 16) + (($e[0] as u32) << 24)
+    };
+}
+
+macro_rules! char_lit_swapped {
+    ($e:expr) => {
+        ($e[0] as u32) + (($e[1] as u32) << 8) + (($e[2] as u32) << 16) + (($e[3] as u32) << 24)
+    };
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SecProtocolType {
+    FTP = char_lit!(b"ftp "),
+    FTPAccount = char_lit!(b"ftpa"),
+    HTTP = char_lit!(b"http"),
+    IRC = char_lit!(b"irc "),
+    NNTP = char_lit!(b"nntp"),
+    POP3 = char_lit!(b"pop3"),
+    SMTP = char_lit!(b"smtp"),
+    SOCKS = char_lit!(b"sox "),
+    IMAP = char_lit!(b"imap"),
+    LDAP = char_lit!(b"ldap"),
+    AppleTalk = char_lit!(b"atlk"),
+    AFP = char_lit!(b"afp "),
+    Telnet = char_lit!(b"teln"),
+    SSH = char_lit!(b"ssh "),
+    FTPS = char_lit!(b"ftps"),
+    HTTPS = char_lit!(b"htps"),
+    HTTPProxy = char_lit!(b"htpx"),
+    HTTPSProxy = char_lit!(b"htsx"),
+    FTPProxy = char_lit!(b"ftpx"),
+    CIFS = char_lit!(b"cifs"),
+    SMB = char_lit!(b"smb "),
+    RTSP = char_lit!(b"rtsp"),
+    RTSPProxy = char_lit!(b"rtsx"),
+    DAAP = char_lit!(b"daap"),
+    EPPC = char_lit!(b"eppc"),
+    IPP = char_lit!(b"ipp "),
+    NNTPS = char_lit!(b"ntps"),
+    LDAPS = char_lit!(b"ldps"),
+    TelnetS = char_lit!(b"tels"),
+    IMAPS = char_lit!(b"imps"),
+    IRCS = char_lit!(b"ircs"),
+    POP3S = char_lit!(b"pops"),
+    CVSpserver = char_lit!(b"cvsp"),
+    SVN = char_lit!(b"svn "),
+    Any = 0,
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SecAuthenticationType {
+    // [sic] Apple has got two related enums each with a different endianness!
+    NTLM = char_lit_swapped!(b"ntlm"),
+    MSN = char_lit_swapped!(b"msna"),
+    DPA = char_lit_swapped!(b"dpaa"),
+    RPA = char_lit_swapped!(b"rpaa"),
+    HTTPBasic = char_lit_swapped!(b"http"),
+    HTTPDigest = char_lit_swapped!(b"httd"),
+    HTMLForm = char_lit_swapped!(b"form"),
+    Default = char_lit_swapped!(b"dflt"),
+    Any = 0,
 }
 
 extern "C" {
@@ -31,6 +100,68 @@ extern "C" {
         password: *const c_void,
         usePassword: Boolean,
     ) -> OSStatus;
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainFindGenericPassword(
+        keychainOrArray: CFTypeRef,
+        serviceNameLength: u32,
+        serviceName: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        passwordLength: *mut u32,
+        passwordData: *mut *mut c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainFindInternetPassword(
+        keychainOrArray: CFTypeRef,
+        serverNameLength: u32,
+        serverName: *const c_char,
+        securityDomainLength: u32,
+        securityDomain: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        pathLength: u32,
+        path: *const c_char,
+        port: u16,
+        protocol: SecProtocolType,
+        authenticationType: SecAuthenticationType,
+        passwordLength: *mut u32,
+        passwordData: *mut *mut c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainAddGenericPassword(
+        keychain: SecKeychainRef,
+        serviceNameLength: u32,
+        serviceName: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        passwordLength: u32,
+        passwordData: *const c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainAddInternetPassword(
+        keychain: SecKeychainRef,
+        serverNameLength: u32,
+        serverName: *const c_char,
+        securityDomainLength: u32,
+        securityDomain: *const c_char,
+        accountNameLength: u32,
+        accountName: *const c_char,
+        pathLength: u32,
+        path: *const c_char,
+        port: u16,
+        protocol: SecProtocolType,
+        authenticationType: SecAuthenticationType,
+        passwordLength: u32,
+        passwordData: *const c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
     pub fn SecKeychainSetSettings(
         keychain: SecKeychainRef,
         newSettings: *const SecKeychainSettings,

--- a/security-framework-sys/src/keychain_item.rs
+++ b/security-framework-sys/src/keychain_item.rs
@@ -1,5 +1,24 @@
-use core_foundation_sys::base::CFTypeID;
+use base::{SecKeychainAttributeList, SecKeychainItemRef};
+use core_foundation_sys::base::{CFTypeID, OSStatus};
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use libc::c_void;
 
 extern "C" {
     pub fn SecKeychainItemGetTypeID() -> CFTypeID;
+
+    pub fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) -> OSStatus;
+
+    pub fn SecItemUpdate(query: CFDictionaryRef, attributesToUpdate: CFDictionaryRef) -> OSStatus;
+
+    pub fn SecKeychainItemModifyAttributesAndData(
+        itemRef: SecKeychainItemRef,
+        attrList: *const SecKeychainAttributeList,
+        length: u32,
+        data: *const c_void,
+    ) -> OSStatus;
+
+    pub fn SecKeychainItemFreeContent(
+        attrList: *mut SecKeychainAttributeList,
+        data: *mut c_void,
+    ) -> OSStatus;
 }

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://sfackler.github.io/rust-security-framework/doc/v0.2")]
 #![allow(bad_style)]
 
+extern crate MacTypes_sys;
 extern crate core_foundation_sys;
 extern crate libc;
 

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -31,3 +31,9 @@ nightly = []
 
 [[example]]
 name = "client"
+
+[[example]]
+name = "find_internet_password"
+
+[[example]]
+name = "set_internet_password"

--- a/security-framework/examples/find_internet_password.rs
+++ b/security-framework/examples/find_internet_password.rs
@@ -1,8 +1,11 @@
 extern crate security_framework;
+#[cfg(target_os = "mac_os")]
 use security_framework::os::macos::keychain::SecKeychain;
+#[cfg(target_os = "mac_os")]
 use security_framework::os::macos::passwords::*;
 
 fn main() {
+    #[cfg(target_os = "mac_os")] {
     let hostname = "example.com";
     let username = "rusty";
     let res = SecKeychain::default().unwrap().find_internet_password(
@@ -31,4 +34,4 @@ fn main() {
                 username, hostname, err);
         }
     }
-}
+}}

--- a/security-framework/examples/find_internet_password.rs
+++ b/security-framework/examples/find_internet_password.rs
@@ -1,0 +1,34 @@
+extern crate security_framework;
+use security_framework::os::macos::keychain::SecKeychain;
+use security_framework::os::macos::passwords::*;
+
+fn main() {
+    let hostname = "example.com";
+    let username = "rusty";
+    let res = SecKeychain::default().unwrap().find_internet_password(
+        hostname,
+        None,
+        username,
+        "",
+        None,
+        SecProtocolType::Any,
+        SecAuthenticationType::Any,
+    );
+    match res {
+        Ok((password, _)) => {
+            println!(
+                "Password for {}@{} is {} bytes long",
+                username,
+                hostname,
+                password.len()
+            );
+        }
+        Err(err) if err.code() == -128 => {
+            eprintln!("Account was found in the Keychain, but user denied access");
+        }
+        Err(err) => {
+            eprintln!("Password not found. Open Keychain Access.app and add internet password for '{}' at 'https://{}': {:?}",
+                username, hostname, err);
+        }
+    }
+}

--- a/security-framework/examples/set_internet_password.rs
+++ b/security-framework/examples/set_internet_password.rs
@@ -1,8 +1,11 @@
 extern crate security_framework;
+#[cfg(target_os = "mac_os")]
 use security_framework::os::macos::keychain::SecKeychain;
+#[cfg(target_os = "mac_os")]
 use security_framework::os::macos::passwords::*;
 
 fn main() {
+    #[cfg(target_os = "mac_os")] {
     let hostname = "example.com";
     let username = "rusty";
     let password = b"oxidize";
@@ -28,4 +31,4 @@ fn main() {
             eprintln!("Could not set password: {:?}", err);
         }
     }
-}
+}}

--- a/security-framework/examples/set_internet_password.rs
+++ b/security-framework/examples/set_internet_password.rs
@@ -1,0 +1,31 @@
+extern crate security_framework;
+use security_framework::os::macos::keychain::SecKeychain;
+use security_framework::os::macos::passwords::*;
+
+fn main() {
+    let hostname = "example.com";
+    let username = "rusty";
+    let password = b"oxidize";
+
+    let res = SecKeychain::default().unwrap().set_internet_password(
+        hostname,
+        None,
+        username,
+        "",
+        None,
+        SecProtocolType::HTTPS,
+        SecAuthenticationType::HTMLForm,
+        password,
+    );
+    match res {
+        Ok(_) => {
+            println!(
+                "Password set for {}@{}. You can read it using find_internet_password example",
+                username, hostname
+            );
+        }
+        Err(err) => {
+            eprintln!("Could not set password: {:?}", err);
+        }
+    }
+}

--- a/security-framework/src/os/macos/mod.rs
+++ b/security-framework/src/os/macos/mod.rs
@@ -11,6 +11,7 @@ pub mod item;
 pub mod key;
 pub mod keychain;
 pub mod keychain_item;
+pub mod passwords;
 pub mod secure_transport;
 pub mod transform;
 

--- a/security-framework/src/os/macos/passwords.rs
+++ b/security-framework/src/os/macos/passwords.rs
@@ -1,0 +1,514 @@
+//! Password support.
+
+use core_foundation::array::CFArray;
+use core_foundation::base::TCFType;
+use os::macos::keychain::SecKeychain;
+use os::macos::keychain_item::SecKeychainItem;
+pub use security_framework_sys::keychain::{SecAuthenticationType, SecProtocolType};
+use security_framework_sys::keychain::{
+    SecKeychainAddGenericPassword, SecKeychainAddInternetPassword, SecKeychainFindGenericPassword,
+    SecKeychainFindInternetPassword,
+};
+use security_framework_sys::keychain_item::{
+    SecKeychainItemDelete, SecKeychainItemFreeContent, SecKeychainItemModifyAttributesAndData,
+};
+use std::fmt;
+use std::fmt::Write;
+use std::ops::Deref;
+use std::ptr;
+use std::slice;
+
+use base::Result;
+use cvt;
+
+/// Password slice. Use `.as_ref()` to get `&[u8]` or `.to_owned()` to get `Vec<u8>`
+pub struct SecKeychainItemPassword {
+    data: *const u8,
+    data_len: usize,
+}
+
+impl fmt::Debug for SecKeychainItemPassword {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for _ in 0..self.data_len {
+            f.write_char('•')?;
+        }
+        Ok(())
+    }
+}
+
+impl AsRef<[u8]> for SecKeychainItemPassword {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts(self.data, self.data_len) }
+    }
+}
+
+impl Deref for SecKeychainItemPassword {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl Drop for SecKeychainItemPassword {
+    fn drop(&mut self) {
+        unsafe {
+            SecKeychainItemFreeContent(ptr::null_mut(), self.data as *mut _);
+        }
+    }
+}
+
+impl SecKeychainItem {
+    /// Modify keychain item in-place, replacing its password with the given one
+    pub fn set_password(&mut self, password: &[u8]) -> Result<()> {
+        unsafe {
+            cvt(SecKeychainItemModifyAttributesAndData(
+                self.as_CFTypeRef() as *mut _,
+                ptr::null(),
+                password.len() as u32,
+                password.as_ptr() as *const _,
+            ))?;
+        }
+        Ok(())
+    }
+
+    /// Delete this item from its keychain
+    pub fn delete(self) {
+        unsafe {
+            SecKeychainItemDelete(self.as_CFTypeRef() as *mut _);
+        }
+    }
+}
+
+/// Find a generic password.
+///
+/// The underlying system supports passwords with 0 values, so this
+/// returns a vector of bytes rather than a string.
+///
+/// * `keychains` is an array of keychains to search or None to search
+///   the default keychain.
+/// * `service` is the name of the service to search for.
+/// * `account` is the name of the account to search for.
+pub fn find_generic_password(
+    keychains: Option<&[SecKeychain]>,
+    service: &str,
+    account: &str,
+) -> Result<(SecKeychainItemPassword, SecKeychainItem)> {
+    let keychains_or_none = keychains.map(|refs| CFArray::from_CFTypes(refs));
+
+    let keychains_or_null = match keychains_or_none {
+        None => ptr::null(),
+        Some(ref keychains) => keychains.as_CFTypeRef(),
+    };
+
+    let mut data_len = 0;
+    let mut data = ptr::null_mut();
+    let mut item = ptr::null_mut();
+
+    unsafe {
+        cvt(SecKeychainFindGenericPassword(
+            keychains_or_null,
+            service.len() as u32,
+            service.as_ptr() as *const _,
+            account.len() as u32,
+            account.as_ptr() as *const _,
+            &mut data_len,
+            &mut data,
+            &mut item,
+        ))?;
+        Ok((
+            SecKeychainItemPassword {
+                data: data as *const _,
+                data_len: data_len as usize,
+            },
+            SecKeychainItem::wrap_under_create_rule(item),
+        ))
+    }
+}
+
+/// * `keychains` is an array of keychains to search or None to search
+///   the default keychain.
+/// * `server`: server name.
+/// * `security_domain`: security domain. This parameter is optional.
+/// * `account`: account name.
+/// * `path`: the path.
+/// * `port`: The TCP/IP port number.
+/// * `protocol`: The protocol associated with this password.
+/// * `authentication_type`: The authentication scheme used.
+pub fn find_internet_password(
+    keychains: Option<&[SecKeychain]>,
+    server: &str,
+    security_domain: Option<&str>,
+    account: &str,
+    path: &str,
+    port: Option<u16>,
+    protocol: SecProtocolType,
+    authentication_type: SecAuthenticationType,
+) -> Result<(SecKeychainItemPassword, SecKeychainItem)> {
+    let keychains_or_none = keychains.map(|refs| CFArray::from_CFTypes(refs));
+
+    let keychains_or_null = match keychains_or_none {
+        None => ptr::null(),
+        Some(ref keychains) => keychains.as_CFTypeRef(),
+    };
+
+    let mut data_len = 0;
+    let mut data = ptr::null_mut();
+    let mut item = ptr::null_mut();
+
+    unsafe {
+        cvt(SecKeychainFindInternetPassword(
+            keychains_or_null,
+            server.len() as u32,
+            server.as_ptr() as *const _,
+            security_domain.map(|s| s.len() as u32).unwrap_or(0),
+            security_domain
+                .map(|s| s.as_ptr() as *const _)
+                .unwrap_or(ptr::null()),
+            account.len() as u32,
+            account.as_ptr() as *const _,
+            path.len() as u32,
+            path.as_ptr() as *const _,
+            port.unwrap_or(0),
+            protocol,
+            authentication_type,
+            &mut data_len,
+            &mut data,
+            &mut item,
+        ))?;
+        Ok((
+            SecKeychainItemPassword {
+                data: data as *const _,
+                data_len: data_len as usize,
+            },
+            SecKeychainItem::wrap_under_create_rule(item),
+        ))
+    }
+}
+
+impl SecKeychain {
+    /// Find application password in this keychain
+    pub fn find_generic_password(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<(SecKeychainItemPassword, SecKeychainItem)> {
+        find_generic_password(Some(&[self.clone()]), service, account)
+    }
+
+    /// Find internet password in this keychain
+    pub fn find_internet_password(
+        &self,
+        server: &str,
+        security_domain: Option<&str>,
+        account: &str,
+        path: &str,
+        port: Option<u16>,
+        protocol: SecProtocolType,
+        authentication_type: SecAuthenticationType,
+    ) -> Result<(SecKeychainItemPassword, SecKeychainItem)> {
+        find_internet_password(
+            Some(&[self.clone()]),
+            server,
+            security_domain,
+            account,
+            path,
+            port,
+            protocol,
+            authentication_type,
+        )
+    }
+
+    /// Update existing or add new internet password
+    pub fn set_internet_password(
+        &self,
+        server: &str,
+        security_domain: Option<&str>,
+        account: &str,
+        path: &str,
+        port: Option<u16>,
+        protocol: SecProtocolType,
+        authentication_type: SecAuthenticationType,
+        password: &[u8],
+    ) -> Result<()> {
+        match self.find_internet_password(
+            server,
+            security_domain,
+            account,
+            path,
+            port,
+            protocol,
+            authentication_type,
+        ) {
+            Ok((_, mut item)) => item.set_password(password),
+            _ => self.add_internet_password(
+                server,
+                security_domain,
+                account,
+                path,
+                port,
+                protocol,
+                authentication_type,
+                password,
+            ),
+        }
+    }
+
+    /// Set a generic password.
+    ///
+    /// * `keychain_opt` is the keychain to use or None to use the default
+    ///   keychain.
+    /// * `service` is the associated service name for the password.
+    /// * `account` is the associated account name for the password.
+    /// * `password` is the password itself.
+    pub fn set_generic_password(
+        &self,
+        service: &str,
+        account: &str,
+        password: &[u8],
+    ) -> Result<()> {
+        match self.find_generic_password(service, account) {
+            Ok((_, mut item)) => item.set_password(password),
+            _ => self.add_generic_password(service, account, password),
+        }
+    }
+
+    /// Add application password to the keychain, without checking if it exists already
+    ///
+    /// See `set_generic_password()`
+    pub fn add_generic_password(
+        &self,
+        service: &str,
+        account: &str,
+        password: &[u8],
+    ) -> Result<()> {
+        unsafe {
+            cvt(SecKeychainAddGenericPassword(
+                self.as_CFTypeRef() as *mut _,
+                service.len() as u32,
+                service.as_ptr() as *const _,
+                account.len() as u32,
+                account.as_ptr() as *const _,
+                password.len() as u32,
+                password.as_ptr() as *const _,
+                ptr::null_mut(),
+            ))?;
+        }
+        Ok(())
+    }
+
+    /// Add internet password to the keychain, without checking if it exists already
+    ///
+    /// See `set_internet_password()`
+    pub fn add_internet_password(
+        &self,
+        server: &str,
+        security_domain: Option<&str>,
+        account: &str,
+        path: &str,
+        port: Option<u16>,
+        protocol: SecProtocolType,
+        authentication_type: SecAuthenticationType,
+        password: &[u8],
+    ) -> Result<()> {
+        unsafe {
+            cvt(SecKeychainAddInternetPassword(
+                self.as_CFTypeRef() as *mut _,
+                server.len() as u32,
+                server.as_ptr() as *const _,
+                security_domain.map(|s| s.len() as u32).unwrap_or(0),
+                security_domain
+                    .map(|s| s.as_ptr() as *const _)
+                    .unwrap_or(ptr::null()),
+                account.len() as u32,
+                account.as_ptr() as *const _,
+                path.len() as u32,
+                path.as_ptr() as *const _,
+                port.unwrap_or(0),
+                protocol,
+                authentication_type,
+                password.len() as u32,
+                password.as_ptr() as *const _,
+                ptr::null_mut(),
+            ))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use os::macos::keychain::{CreateOptions, SecKeychain};
+    use tempdir::TempDir;
+
+    fn temp_keychain_setup(name: &str) -> (TempDir, SecKeychain) {
+        let dir = TempDir::new("passwords").expect("TempDir::new");
+        let keychain = CreateOptions::new()
+            .password("foobar")
+            .create(dir.path().join(name.to_string() + ".keychain"))
+            .expect("create keychain");
+
+        (dir, keychain)
+    }
+
+    fn temp_keychain_teardown(dir: TempDir) -> () {
+        dir.close().expect("temp dir close");
+    }
+
+    #[test]
+    fn missing_password_temp() {
+        let (dir, keychain) = temp_keychain_setup("missing_password");
+        let keychains = vec![keychain];
+
+        let service = "temp_this_service_does_not_exist";
+        let account = "this_account_is_bogus";
+        let found = find_generic_password(Some(&keychains), service, account);
+
+        assert!(found.is_err());
+
+        temp_keychain_teardown(dir);
+    }
+
+    #[test]
+    #[cfg(feature = "default_keychain_tests")]
+    fn missing_password_default() {
+        let service = "default_this_service_does_not_exist";
+        let account = "this_account_is_bogus";
+        let found = find_generic_password(None, service, account);
+
+        assert!(found.is_err());
+    }
+
+    #[test]
+    fn round_trip_password_temp() {
+        let (dir, keychain) = temp_keychain_setup("round_trip_password");
+
+        let service = "test_round_trip_password_temp";
+        let account = "temp_this_is_the_test_account";
+        let password = String::from("deadbeef").into_bytes();
+
+        keychain
+            .set_generic_password(service, account, &password)
+            .expect("set_generic_password");
+        let (found, item) = keychain
+            .find_generic_password(service, account)
+            .expect("find_generic_password");
+        assert_eq!(found.to_owned(), password);
+
+        item.delete();
+
+        temp_keychain_teardown(dir);
+    }
+
+    #[test]
+    #[cfg(feature = "default_keychain_tests")]
+    fn round_trip_password_default() {
+        let service = "test_round_trip_password_default";
+        let account = "this_is_the_test_account";
+        let password = String::from("deadbeef").into_bytes();
+
+        SecKeychain::default()
+            .expect("default keychain")
+            .set_generic_password(service, account, &password)
+            .expect("set_generic_password");
+        let (found, item) =
+            find_generic_password(None, service, account).expect("find_generic_password");
+        assert_eq!(&*found, &password[..]);
+
+        item.delete();
+    }
+
+    #[test]
+    fn change_password_temp() {
+        let (dir, keychain) = temp_keychain_setup("change_password");
+        let keychains = vec![keychain];
+
+        let service = "test_change_password_temp";
+        let account = "this_is_the_test_account";
+        let pw1 = String::from("password1").into_bytes();
+        let pw2 = String::from("password2").into_bytes();
+
+        keychains[0]
+            .set_generic_password(service, account, &pw1)
+            .expect("set_generic_password1");
+        let (found, _) = find_generic_password(Some(&keychains), service, account)
+            .expect("find_generic_password1");
+        assert_eq!(found.as_ref(), &pw1[..]);
+
+        keychains[0]
+            .set_generic_password(service, account, &pw2)
+            .expect("set_generic_password2");
+        let (found, item) = find_generic_password(Some(&keychains), service, account)
+            .expect("find_generic_password2");
+        assert_eq!(&*found, &pw2[..]);
+
+        item.delete();
+
+        temp_keychain_teardown(dir);
+    }
+
+    #[test]
+    #[cfg(feature = "default_keychain_tests")]
+    fn change_password_default() {
+        let service = "test_change_password_default";
+        let account = "this_is_the_test_account";
+        let pw1 = String::from("password1").into_bytes();
+        let pw2 = String::from("password2").into_bytes();
+
+        SecKeychain::default()
+            .expect("default keychain")
+            .set_generic_password(service, account, &pw1)
+            .expect("set_generic_password1");
+        let (found, _) =
+            find_generic_password(None, service, account).expect("find_generic_password1");
+        assert_eq!(found.to_owned(), pw1);
+
+        SecKeychain::default()
+            .expect("default keychain")
+            .set_generic_password(service, account, &pw2)
+            .expect("set_generic_password2");
+        let (found, item) =
+            find_generic_password(None, service, account).expect("find_generic_password2");
+        assert_eq!(found.to_owned(), pw2);
+
+        item.delete();
+    }
+
+    #[test]
+    fn cross_keychain_corruption_temp() {
+        let (dir1, keychain1) = temp_keychain_setup("cross_corrupt1");
+        let (dir2, keychain2) = temp_keychain_setup("cross_corrupt2");
+        let keychains1 = vec![keychain1.clone()];
+        let keychains2 = vec![keychain2.clone()];
+        let both_keychains = vec![keychain1, keychain2];
+
+        let service = "temp_this_service_does_not_exist";
+        let account = "this_account_is_bogus";
+        let password = String::from("deadbeef").into_bytes();
+
+        // Make sure this password doesn't exist in either keychain.
+        let found = find_generic_password(Some(&both_keychains), service, account);
+        assert!(found.is_err());
+
+        // Set a password in one keychain.
+        keychains1[0]
+            .set_generic_password(service, account, &password)
+            .expect("set_generic_password");
+
+        // Make sure it's found in that keychain.
+        let (found, item) = find_generic_password(Some(&keychains1), service, account)
+            .expect("find_generic_password1");
+        assert_eq!(found.to_owned(), password);
+
+        // Make sure it's _not_ found in the other keychain.
+        let found = find_generic_password(Some(&keychains2), service, account);
+        assert!(found.is_err());
+
+        // Cleanup.
+        item.delete();
+
+        temp_keychain_teardown(dir1);
+        temp_keychain_teardown(dir2);
+    }
+}

--- a/security-framework/src/random.rs
+++ b/security-framework/src/random.rs
@@ -1,6 +1,5 @@
 //! Randomness support.
 
-use libc::c_void;
 use security_framework_sys::random::*;
 use std::io;
 
@@ -19,7 +18,7 @@ impl Default for SecRandom {
 impl SecRandom {
     /// Fills the buffer with cryptographically secure random bytes.
     pub fn copy_bytes(&self, buf: &mut [u8]) -> io::Result<()> {
-        if unsafe { SecRandomCopyBytes(self.0, buf.len(), buf.as_mut_ptr() as *mut c_void) } == 0 {
+        if unsafe { SecRandomCopyBytes(self.0, buf.len(), buf.as_mut_ptr() as *mut _) } == 0 {
             Ok(())
         } else {
             Err(io::Error::last_os_error())


### PR DESCRIPTION
Based on #17, with additions:

* Supports "Internet" passwords in addition to generic app passwords.
* Adds methods to `SecKeychainItem` instead of using standalone functions, which removes some repetition from the code.
* Avoids creating temporary `CString`s, since Keychain supports explicit string lengths.
* Includes examples.