### PR TITLE
Remove dependency on MacTypes-sys

### DIFF
--- a/security-framework-sys/Cargo.toml
+++ b/security-framework-sys/Cargo.toml
@@ -14,7 +14,6 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2.47"
-MacTypes-sys = "2.1.0"
 core-foundation-sys = "0.6.2"
 
 [features]

--- a/security-framework-sys/src/base.rs
+++ b/security-framework-sys/src/base.rs
@@ -1,7 +1,6 @@
 use core_foundation_sys::base::OSStatus;
 use core_foundation_sys::string::CFStringRef;
 use libc::c_void;
-use MacTypes_sys::OSType;
 
 pub enum OpaqueSecKeychainRef {}
 pub type SecKeychainRef = *mut OpaqueSecKeychainRef;
@@ -9,7 +8,8 @@ pub type SecKeychainRef = *mut OpaqueSecKeychainRef;
 pub enum OpaqueSecKeychainItemRef {}
 pub type SecKeychainItemRef = *mut OpaqueSecKeychainItemRef;
 
-pub type SecKeychainAttrType = OSType;
+// OSType from MacTypes.h
+pub type SecKeychainAttrType = u32;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_root_url = "https://sfackler.github.io/rust-security-framework/doc/v0.2")]
 #![allow(bad_style)]
 
-extern crate MacTypes_sys;
 extern crate core_foundation_sys;
 extern crate libc;
 


### PR DESCRIPTION
MacTypes-sys APSL-2.0 license is preventing this library use
in a large number of contexts.