### PR TITLE
Add Authorization Services support

### DIFF
--- a/security-framework-sys/Cargo.toml
+++ b/security-framework-sys/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["os::macos-apis", "external-ffi-bindings"]
 
 [dependencies]
 core-foundation-sys = "0.7"
+libc = "0.2.47"
 
 [features]
 OSX_10_9 = []

--- a/security-framework-sys/src/authorization.rs
+++ b/security-framework-sys/src/authorization.rs
@@ -1,0 +1,145 @@
+use core_foundation_sys::base::CFTypeRef;
+use core_foundation_sys::base::OSStatus;
+use core_foundation_sys::bundle::CFBundleRef;
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use core_foundation_sys::string::CFStringRef;
+use std::os::raw::{c_char, c_void};
+
+pub const errAuthorizationSuccess: OSStatus = 0;
+pub const errAuthorizationInvalidSet: OSStatus = -60001;
+pub const errAuthorizationInvalidRef: OSStatus = -60002;
+pub const errAuthorizationInvalidTag: OSStatus = -60003;
+pub const errAuthorizationInvalidPointer: OSStatus = -60004;
+pub const errAuthorizationDenied: OSStatus = -60005;
+pub const errAuthorizationCanceled: OSStatus = -60006;
+pub const errAuthorizationInteractionNotAllowed: OSStatus = -60007;
+pub const errAuthorizationInternal: OSStatus = -60008;
+pub const errAuthorizationExternalizeNotAllowed: OSStatus = -60009;
+pub const errAuthorizationInternalizeNotAllowed: OSStatus = -60010;
+pub const errAuthorizationInvalidFlags: OSStatus = -60011;
+pub const errAuthorizationToolExecuteFailure: OSStatus = -60031;
+pub const errAuthorizationToolEnvironmentError: OSStatus = -60032;
+pub const errAuthorizationBadAddress: OSStatus = -60033;
+
+pub type AuthorizationFlags = u32;
+pub const kAuthorizationFlagDefaults: AuthorizationFlags = 0;
+pub const kAuthorizationFlagInteractionAllowed: AuthorizationFlags = 1;
+pub const kAuthorizationFlagExtendRights: AuthorizationFlags = 2;
+pub const kAuthorizationFlagPartialRights: AuthorizationFlags = 4;
+pub const kAuthorizationFlagDestroyRights: AuthorizationFlags = 8;
+pub const kAuthorizationFlagPreAuthorize: AuthorizationFlags = 16;
+
+pub type AuthorizationRef = *mut c_void;
+pub type AuthorizationString = *const c_char;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct AuthorizationItem {
+    pub name: AuthorizationString,
+    pub valueLength: usize,
+    pub value: *mut c_void,
+    pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct AuthorizationItemSet {
+    pub count: u32,
+    pub items: *mut AuthorizationItem,
+}
+
+pub const kAuthorizationExternalFormLength: usize = 32;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct AuthorizationExternalForm {
+    pub bytes: [c_char; kAuthorizationExternalFormLength],
+}
+
+pub type AuthorizationRights = AuthorizationItemSet;
+pub type AuthorizationEnvironment = AuthorizationItemSet;
+
+pub type AuthorizationAsyncCallback =
+    unsafe extern "C" fn(err: OSStatus, blockAuthorizedRights: *mut AuthorizationRights);
+
+extern "C" {
+    pub fn AuthorizationCreate(
+        rights: *const AuthorizationRights,
+        environment: *const AuthorizationEnvironment,
+        flags: AuthorizationFlags,
+        authorization: *mut AuthorizationRef,
+    ) -> OSStatus;
+
+    pub fn AuthorizationFree(
+        authorization: AuthorizationRef,
+        flags: AuthorizationFlags,
+    ) -> OSStatus;
+
+    pub fn AuthorizationCopyRights(
+        authorization: AuthorizationRef,
+        rights: *const AuthorizationRights,
+        environment: *const AuthorizationEnvironment,
+        flags: AuthorizationFlags,
+        authorizedRights: *mut *mut AuthorizationRights,
+    ) -> OSStatus;
+
+    pub fn AuthorizationCopyRightsAsync(
+        authorization: AuthorizationRef,
+        rights: *const AuthorizationRights,
+        environment: *const AuthorizationEnvironment,
+        flags: AuthorizationFlags,
+        callbackBlock: AuthorizationAsyncCallback,
+    );
+
+    pub fn AuthorizationCopyInfo(
+        authorization: AuthorizationRef,
+        tag: AuthorizationString,
+        info: *mut *mut AuthorizationItemSet,
+    ) -> OSStatus;
+
+    pub fn AuthorizationMakeExternalForm(
+        authorization: AuthorizationRef,
+        extForm: *mut AuthorizationExternalForm,
+    ) -> OSStatus;
+
+    pub fn AuthorizationCreateFromExternalForm(
+        extForm: *const AuthorizationExternalForm,
+        authorization: *mut AuthorizationRef,
+    ) -> OSStatus;
+
+    pub fn AuthorizationFreeItemSet(set: *mut AuthorizationItemSet) -> OSStatus;
+
+    pub fn AuthorizationRightGet(
+        rightName: *const c_char,
+        rightDefinition: *mut CFDictionaryRef,
+    ) -> OSStatus;
+
+    pub fn AuthorizationRightSet(
+        authorization: AuthorizationRef,
+        rightName: *const c_char,
+        rightDefinition: CFTypeRef,
+        descriptionKey: CFStringRef,
+        bundle: CFBundleRef,
+        localeTableName: CFStringRef,
+    ) -> OSStatus;
+
+    pub fn AuthorizationRightRemove(
+        authorization: AuthorizationRef,
+        rightName: *const c_char,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn AuthorizationExecuteWithPrivileges(
+        authorization: AuthorizationRef,
+        pathToTool: *const c_char,
+        options: AuthorizationFlags,
+        arguments: *const *mut c_char,
+        communicationsPipe: *mut *mut libc::FILE,
+    ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn AuthorizationCopyPrivilegedReference(
+        authorization: *mut AuthorizationRef,
+        flags: AuthorizationFlags,
+    ) -> OSStatus;
+}

--- a/security-framework-sys/src/base.rs
+++ b/security-framework-sys/src/base.rs
@@ -47,6 +47,7 @@ pub const errSecIO: OSStatus = -36;
 pub const errSecParam: OSStatus = -50;
 pub const errSecBadReq: OSStatus = -909;
 pub const errSecAuthFailed: OSStatus = -25293;
+pub const errSecConversionError: OSStatus = -67594;
 pub const errSecTrustSettingDeny: OSStatus = -67654;
 pub const errSecNotTrusted: OSStatus = -67843;
 pub const errSecNoTrustSettings: OSStatus = -25263;

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -1,12 +1,18 @@
 #![allow(bad_style)]
 
 extern crate core_foundation_sys;
+extern crate libc;
 
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), link(name = "Security", kind = "framework"))]
+#[cfg_attr(
+    any(target_os = "macos", target_os = "ios"),
+    link(name = "Security", kind = "framework")
+)]
 extern "C" {}
 
 #[cfg(target_os = "macos")]
 pub mod access;
+#[cfg(target_os = "macos")]
+pub mod authorization;
 pub mod base;
 pub mod certificate;
 #[cfg(target_os = "macos")]

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -17,6 +17,7 @@ security-framework-sys = { version = "0.4", path = "../security-framework-sys" }
 core-foundation = "0.7"
 core-foundation-sys = "0.7"
 libc = "0.2.47"
+bitflags = "1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -1,0 +1,641 @@
+//! Authorization Services support.
+
+/// # Potential improvements
+///
+/// * When generic specialization stabilizes prevent copying from CString
+///   arguments.
+/// * AuthorizationCopyRightsAsync
+/// * Provide constants for well known item names
+use base::{Error, Result};
+use core_foundation::base::{CFTypeRef, TCFType};
+use core_foundation::bundle::CFBundleRef;
+use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
+use core_foundation::string::{CFString, CFStringRef};
+use security_framework_sys::authorization as sys;
+use security_framework_sys::base::errSecConversionError;
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::mem::MaybeUninit;
+use std::os::raw::c_void;
+
+macro_rules! optional_str_to_cfref {
+    ($string:ident) => {{
+        $string
+            .map(CFString::new)
+            .map_or(std::ptr::null(), |cfs| cfs.as_concrete_TypeRef())
+    }};
+}
+
+macro_rules! cstring_or_err {
+    ($x:expr) => {{
+        CString::new($x).map_err(|_| Error::from_code(errSecConversionError))
+    }};
+}
+
+bitflags! {
+    /// The flags used to specify authorization options.
+    pub struct Flags: sys::AuthorizationFlags {
+        /// An empty flag set that you use as a placeholder when you don't want
+        /// any of the other flags.
+        const DEFAULTS = sys::kAuthorizationFlagDefaults;
+
+        /// A flag that permits user interaction as needed.
+        const INTERACTION_ALLOWED = sys::kAuthorizationFlagInteractionAllowed;
+
+        /// A flag that permits the Security Server to attempt to grant the
+        /// rights requested.
+        const EXTEND_RIGHTS = sys::kAuthorizationFlagExtendRights;
+
+        /// A flag that permits the Security Server to grant rights on an
+        /// individual basis.
+        const PARTIAL_RIGHTS = sys::kAuthorizationFlagPartialRights;
+
+        /// A flag that instructs the Security Server to revoke authorization.
+        const DESTROY_RIGHTS = sys::kAuthorizationFlagDestroyRights;
+
+        /// A flag that instructs the Security Server to preauthorize the rights
+        /// requested.
+        const PREAUTHORIZE = sys::kAuthorizationFlagPreAuthorize;
+    }
+}
+
+impl Default for Flags {
+    fn default() -> Flags {
+        Flags::DEFAULTS
+    }
+}
+
+/// Information about an authorization right or the environment.
+#[repr(C)]
+pub struct AuthorizationItem(sys::AuthorizationItem);
+
+impl AuthorizationItem {
+    /// The required name of the authorization right or environment data.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn name(&self) -> &str {
+        unsafe {
+            CStr::from_ptr(self.0.name)
+                .to_str()
+                .expect("AuthorizationItem::name failed to convert &str to CStr")
+        }
+    }
+
+    /// The information pertaining to the name field. Do not rely on NULL
+    /// termination of string data.
+    pub fn value(&self) -> Option<&[u8]> {
+        if self.0.value.is_null() {
+            return None;
+        }
+
+        let value =
+            unsafe { std::slice::from_raw_parts(self.0.value as *const u8, self.0.valueLength) };
+
+        Some(value)
+    }
+}
+
+/// A set of authorization items returned and owned by the Security Server.
+#[derive(Debug)]
+#[repr(C)]
+pub struct AuthorizationItemSet<'a> {
+    inner: *const sys::AuthorizationItemSet,
+    is_owned: bool,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> Drop for AuthorizationItemSet<'a> {
+    fn drop(&mut self) {
+        if self.is_owned {
+            unsafe {
+                sys::AuthorizationFreeItemSet(self.inner as *mut sys::AuthorizationItemSet);
+            }
+        }
+    }
+}
+
+/// Used by `AuthorizationItemSetBuilder` to store data pointed to by
+/// `sys::AuthorizationItemSet`.
+#[derive(Debug)]
+pub struct AuthorizationItemSetStorage {
+    /// The layout of this is a little awkward because of the requirements of
+    /// Apple's APIs. `items` contains pointers to data owned by `names` and
+    /// `values`, so we must not modify them once `items` has been set up.
+    names: Vec<CString>,
+    values: Vec<Option<Vec<u8>>>,
+    items: Vec<sys::AuthorizationItem>,
+
+    /// Must not be given to APIs which would attempt to modify it.
+    ///
+    /// See `AuthorizationItemSet` for sets owned by the Security Server which
+    /// are writable.
+    pub set: sys::AuthorizationItemSet,
+}
+
+impl Default for AuthorizationItemSetStorage {
+    fn default() -> Self {
+        AuthorizationItemSetStorage {
+            names: Vec::new(),
+            values: Vec::new(),
+            items: Vec::new(),
+            set: sys::AuthorizationItemSet {
+                count: 0,
+                items: std::ptr::null_mut(),
+            },
+        }
+    }
+}
+
+/// A convenience `AuthorizationItemSetBuilder` builder which enabled you to use
+/// rust types. All names and values passed in will be copied.
+#[derive(Debug, Default)]
+pub struct AuthorizationItemSetBuilder {
+    storage: AuthorizationItemSetStorage,
+}
+
+// Stores AuthorizationItems contiguously, and their items separately
+impl AuthorizationItemSetBuilder {
+    /// Creates a new `AuthorizationItemSetStore`, which simplifies creating
+    /// owned vectors of `AuthorizationItem`s.
+    pub fn new() -> AuthorizationItemSetBuilder {
+        Default::default()
+    }
+
+    /// Adds an AuthorizationItem with the name set to a right and an empty
+    /// value.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn add_right<N: Into<Vec<u8>>>(mut self, name: N) -> Result<Self> {
+        self.storage.names.push(cstring_or_err!(name)?);
+        self.storage.values.push(None);
+        Ok(self)
+    }
+
+    /// Adds an AuthorizationItem with arbitrary data.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn add_data<N, V>(mut self, name: N, value: V) -> Result<Self>
+    where
+        N: Into<Vec<u8>>,
+        V: Into<Vec<u8>>,
+    {
+        self.storage.names.push(cstring_or_err!(name)?);
+        self.storage.values.push(Some(value.into()));
+        Ok(self)
+    }
+
+    /// Adds an AuthorizationItem with NULL terminated string data.
+    ///
+    /// If `name` or `value` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn add_string<N, V>(mut self, name: N, value: V) -> Result<Self>
+    where
+        N: Into<Vec<u8>>,
+        V: Into<Vec<u8>>,
+    {
+        self.storage.names.push(cstring_or_err!(name)?);
+        self.storage
+            .values
+            .push(Some(cstring_or_err!(value)?.to_bytes().to_vec()));
+        Ok(self)
+    }
+
+    /// Creates the `sys::AuthorizationItemSet`, and gives you ownership of the
+    /// data it points to.
+    pub fn build(mut self) -> AuthorizationItemSetStorage {
+        self.storage.items = self
+            .storage
+            .names
+            .iter()
+            .zip(self.storage.values.iter())
+            .map(|(n, v)| sys::AuthorizationItem {
+                name: n.as_ptr(),
+                value: v
+                    .as_ref()
+                    .map_or(std::ptr::null_mut(), |v| v.as_ptr() as *mut c_void),
+                valueLength: v.as_ref().map_or(0, |v| v.len()),
+                flags: 0,
+            })
+            .collect();
+
+        self.storage.set = sys::AuthorizationItemSet {
+            count: self.storage.items.len() as u32,
+            items: self.storage.items.as_ptr() as *mut sys::AuthorizationItem,
+        };
+
+        self.storage
+    }
+}
+
+/// Used by `Authorization::set_item` to define the rules of he right.
+pub enum RightDefinition<'a> {
+    /// The dictionary will contain the keys and values that define the rules.
+    FromDictionary(&'a CFDictionary<CFStringRef, CFTypeRef>),
+
+    /// The specified right's rules will be duplicated.
+    FromExistingRight(&'a str),
+}
+
+/// A wrapper around AuthorizationCreate and functions which operate on an
+/// AuthorizationRef.
+#[derive(Debug)]
+pub struct Authorization {
+    handle: sys::AuthorizationRef,
+    free_flags: Flags,
+}
+
+impl<'a> Authorization {
+    /// Creates an authorization object which has no environment or associated
+    /// rights.
+    pub fn default() -> Result<Self> {
+        Self::new(None, None, Default::default())
+    }
+
+    /// Creates an authorization reference and provides an option to authorize
+    /// or preauthorize rights.
+    ///
+    /// `rights` should be the names of the rights you want to create.
+    ///
+    /// `environment` is used when authorizing or preauthorizing rights. Not
+    /// used in OS X v10.2 and earlier. In macOS 10.3 and later, you can pass
+    /// icon or prompt data to be used in the authentication dialog box. In
+    /// macOS 10.4 and later, you can also pass a user name and password in
+    /// order to authorize a user without user interaction.
+    pub fn new(
+        rights: Option<AuthorizationItemSetStorage>,
+        environment: Option<AuthorizationItemSetStorage>,
+        flags: Flags,
+    ) -> Result<Self> {
+        let rights_ptr = rights.as_ref().map_or(std::ptr::null(), |r| {
+            &r.set as *const sys::AuthorizationItemSet
+        });
+
+        let env_ptr = environment.as_ref().map_or(std::ptr::null(), |e| {
+            &e.set as *const sys::AuthorizationItemSet
+        });
+
+        let mut handle = MaybeUninit::<sys::AuthorizationRef>::uninit();
+
+        let status = unsafe {
+            sys::AuthorizationCreate(rights_ptr, env_ptr, flags.bits(), handle.as_mut_ptr())
+        };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from_code(status));
+        }
+
+        Ok(Authorization {
+            handle: unsafe { handle.assume_init() },
+            free_flags: Default::default(),
+        })
+    }
+
+    /// Internalizes the external representation of an authorization reference.
+    ///
+    /// TODO: TryFrom when security-framework stops supporting rust versions
+    /// which don't have it.
+    pub fn from_external_form(external_form: sys::AuthorizationExternalForm) -> Result<Self> {
+        let mut handle = MaybeUninit::<sys::AuthorizationRef>::uninit();
+
+        let status = unsafe {
+            sys::AuthorizationCreateFromExternalForm(&external_form, handle.as_mut_ptr())
+        };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from_code(status));
+        }
+
+        let auth = Authorization {
+            handle: unsafe { handle.assume_init() },
+            free_flags: Default::default(),
+        };
+
+        Ok(auth)
+    }
+
+    /// By default the rights acquired will be retained by the Security Server.
+    /// Use this to ensure they are destroyed and to prevent shared rights'
+    /// continued used by other processes.
+    #[inline]
+    pub fn destroy_rights(mut self) {
+        self.free_flags = Flags::DESTROY_RIGHTS;
+    }
+
+    /// Retrieve's the right's definition as a dictionary. Use `right_exists`
+    /// if you want to avoid retrieving the dictionary.
+    ///
+    /// `name` can be a wildcard right name.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn get_right<T: Into<Vec<u8>>>(name: T) -> Result<CFDictionary<CFString, CFTypeRef>> {
+        let name = cstring_or_err!(name)?;
+        let mut dict = MaybeUninit::<CFDictionaryRef>::uninit();
+
+        let status = unsafe { sys::AuthorizationRightGet(name.as_ptr(), dict.as_mut_ptr()) };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from_code(status));
+        }
+
+        let dict = unsafe { CFDictionary::wrap_under_create_rule(dict.assume_init()) };
+
+        Ok(dict)
+    }
+
+    /// Checks if a right exists within the policy database. This is the same as
+    /// `get_right`, but avoids a dictionary allocation.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn right_exists<T: Into<Vec<u8>>>(name: T) -> Result<bool> {
+        let name = cstring_or_err!(name)?;
+
+        let status = unsafe { sys::AuthorizationRightGet(name.as_ptr(), std::ptr::null_mut()) };
+
+        Ok(status == sys::errAuthorizationSuccess)
+    }
+
+    /// Removes a right from the policy database.
+    ///
+    /// `name` cannot be a wildcard right name.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn remove_right<T: Into<Vec<u8>>>(&self, name: T) -> Result<()> {
+        let name = cstring_or_err!(name)?;
+
+        let status = unsafe { sys::AuthorizationRightRemove(self.handle, name.as_ptr()) };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from_code(status));
+        }
+
+        Ok(())
+    }
+
+    /// Creates or updates a right entry in the policy database. Your process
+    /// must have a code signature in order to be able to add rights to the
+    /// authorization database.
+    ///
+    /// `name` cannot be a wildcard right.
+    ///
+    /// `definition` can be either a `CFDictionaryRef` containing keys defining
+    /// the rules or a `CFStringRef` representing the name of another right
+    /// whose rules you wish to duplicaate.
+    ///
+    /// `description` is a key which can be used to look up localized
+    /// descriptions.
+    ///
+    /// `bundle` will be used to get localizations from if not the main bundle.
+    ///
+    /// `localeTableName` will be used to get localizations if provided.
+    ///
+    /// If `name` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn set_right<T: Into<Vec<u8>>>(
+        &self,
+        name: T,
+        definition: RightDefinition,
+        description: Option<&str>,
+        bundle: Option<CFBundleRef>,
+        locale: Option<&str>,
+    ) -> Result<()> {
+        let name = cstring_or_err!(name)?;
+
+        let definition_cfstring: CFString;
+        let definition_ref = match definition {
+            RightDefinition::FromDictionary(def) => def.as_CFTypeRef(),
+            RightDefinition::FromExistingRight(def) => {
+                definition_cfstring = CFString::new(def);
+                definition_cfstring.as_CFTypeRef()
+            }
+        };
+
+        let status = unsafe {
+            sys::AuthorizationRightSet(
+                self.handle,
+                name.as_ptr(),
+                definition_ref,
+                optional_str_to_cfref!(description),
+                bundle.unwrap_or(std::ptr::null_mut()),
+                optional_str_to_cfref!(locale),
+            )
+        };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from_code(status));
+        }
+
+        Ok(())
+    }
+
+    /// An authorization plugin can store the results of an authentication
+    /// operation by calling the `SetContextValue` function. You can then
+    /// retrieve this supporting data, such as the user name.
+    ///
+    /// `tag` should specify the type of data the Security Server should return.
+    /// If `None`, all available information is retreieved.
+    ///
+    /// If `tag` isn't convertable to a `CString` it will return
+    /// Err(errSecConversionError).
+    pub fn copy_info<T: Into<Vec<u8>>>(&self, tag: Option<T>) -> Result<AuthorizationItemSet> {
+        let tag_with_nul: CString;
+
+        let tag_ptr = match tag {
+            Some(tag) => {
+                tag_with_nul = cstring_or_err!(tag)?;
+                tag_with_nul.as_ptr()
+            }
+            None => std::ptr::null(),
+        };
+
+        let mut inner = MaybeUninit::<*mut sys::AuthorizationItemSet>::uninit();
+
+        let status =
+            unsafe { sys::AuthorizationCopyInfo(self.handle, tag_ptr, inner.as_mut_ptr()) };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from(status));
+        }
+
+        let set = AuthorizationItemSet {
+            inner: unsafe { inner.assume_init() },
+            is_owned: false,
+            phantom: PhantomData,
+        };
+
+        Ok(set)
+    }
+
+    /// Creates an external representation of an authorization reference so that
+    /// you can transmit it between processes.
+    pub fn make_external_form(&self) -> Result<sys::AuthorizationExternalForm> {
+        let mut external_form = MaybeUninit::<sys::AuthorizationExternalForm>::uninit();
+
+        let status =
+            unsafe { sys::AuthorizationMakeExternalForm(self.handle, external_form.as_mut_ptr()) };
+
+        if status != sys::errAuthorizationSuccess {
+            return Err(Error::from(status));
+        }
+
+        Ok(unsafe { external_form.assume_init() })
+    }
+}
+
+impl Drop for Authorization {
+    fn drop(&mut self) {
+        unsafe {
+            sys::AuthorizationFree(self.handle, self.free_flags.bits());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core_foundation::string::CFString;
+
+    #[test]
+    fn test_create_default_authorization() {
+        Authorization::default().unwrap();
+    }
+
+    #[test]
+    fn test_create_allowed_authorization() -> Result<()> {
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right("system.hdd.smart")?
+            .add_right("system.login.done")?
+            .build();
+
+        Authorization::new(Some(rights), None, Flags::EXTEND_RIGHTS).unwrap();
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_then_destroy_allowed_authorization() -> Result<()> {
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right("system.hdd.smart")?
+            .add_right("system.login.done")?
+            .build();
+
+        let auth = Authorization::new(Some(rights), None, Flags::EXTEND_RIGHTS).unwrap();
+        auth.destroy_rights();
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_authorization_requiring_interaction() -> Result<()> {
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right("system.privilege.admin")?
+            .build();
+
+        let error = Authorization::new(Some(rights), None, Flags::EXTEND_RIGHTS).unwrap_err();
+
+        assert_eq!(error.code(), sys::errAuthorizationInteractionNotAllowed);
+
+        Ok(())
+    }
+
+    fn create_credentials_env() -> Result<AuthorizationItemSetStorage> {
+        let set = AuthorizationItemSetBuilder::new()
+            .add_string(
+                "username",
+                option_env!("USER").expect("You must set the USER environment variable"),
+            )?
+            .add_string(
+                "password",
+                option_env!("PASSWORD").expect("You must set the PASSWORD environment varible"),
+            )?
+            .build();
+
+        Ok(set)
+    }
+
+    #[test]
+    fn test_create_authorization_with_bad_credentials() -> Result<()> {
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right("system.privilege.admin")?
+            .build();
+
+        let env = AuthorizationItemSetBuilder::new()
+            .add_string("username", "Tim Apple")?
+            .add_string("password", "butterfly")?
+            .build();
+
+        let error =
+            Authorization::new(Some(rights), Some(env), Flags::INTERACTION_ALLOWED).unwrap_err();
+
+        assert_eq!(error.code(), sys::errAuthorizationDenied);
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore]
+    fn test_create_authorization_with_credentials() -> Result<()> {
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right("system.privilege.admin")?
+            .build();
+
+        let env = create_credentials_env()?;
+
+        Authorization::new(Some(rights), Some(env), Flags::EXTEND_RIGHTS).unwrap();
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_query_authorization_database() -> Result<()> {
+        assert!(Authorization::right_exists("system.hdd.smart")?);
+        assert!(!Authorization::right_exists("EMPTY")?);
+
+        let dict = Authorization::get_right("system.hdd.smart").unwrap();
+
+        let key = CFString::from_static_string("class");
+        assert!(dict.contains_key(&key));
+
+        let invalid_key = CFString::from_static_string("EMPTY");
+        assert!(!dict.contains_key(&invalid_key));
+
+        Ok(())
+    }
+
+    /// This test will only pass if its process has a valid code signature.
+    #[test]
+    #[ignore]
+    fn test_modify_authorization_database() -> Result<()> {
+        let rights = AuthorizationItemSetBuilder::new()
+            .add_right("config.modify.")?
+            .build();
+
+        let env = create_credentials_env()?;
+
+        let auth = Authorization::new(Some(rights), Some(env), Flags::EXTEND_RIGHTS).unwrap();
+
+        assert!(!Authorization::right_exists("TEST_RIGHT")?);
+
+        auth.set_right(
+            "TEST_RIGHT",
+            RightDefinition::FromExistingRight("system.hdd.smart"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(Authorization::right_exists("TEST_RIGHT")?);
+
+        auth.remove_right("TEST_RIGHT").unwrap();
+
+        assert!(!Authorization::right_exists("TEST_RIGHT")?);
+
+        Ok(())
+    }
+}

--- a/security-framework/src/lib.rs
+++ b/security-framework/src/lib.rs
@@ -8,6 +8,9 @@ extern crate security_framework_sys;
 extern crate core_foundation;
 extern crate core_foundation_sys;
 extern crate libc;
+#[cfg(target_os = "macos")]
+#[macro_use]
+extern crate bitflags;
 
 #[cfg(test)]
 extern crate hex;
@@ -37,6 +40,8 @@ macro_rules! p {
 #[macro_use]
 mod dlsym;
 
+#[cfg(target_os = "macos")]
+pub mod authorization;
 pub mod base;
 pub mod certificate;
 pub mod cipher_suite;

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -36,6 +36,8 @@ fn main() {
         .header("Security/SecureTransport.h")
         .header("Security/SecTrust.h")
         .header("Security/SecTrustSettings.h")
+        .header("Security/Authorization.h")
+        .header("Security/AuthorizationDB.h")
         .flag("-Wno-deprecated-declarations")
         .type_name(|name, _, _| name.to_string())
         .skip_signededness(|s| s.ends_with("Ref") || s.ends_with("Func"))

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -10,6 +10,7 @@ use std::os::raw::*;
 
 #[cfg(target_os = "macos")]
 use security_framework_sys::access::*;
+use security_framework_sys::authorization::*;
 use security_framework_sys::base::*;
 use security_framework_sys::certificate::*;
 use security_framework_sys::cipher_suite::*;


### PR DESCRIPTION
This is my first time writing Rust FFI bindings, I'm happy to make as many changes as are needed.

~I've kept in some documented potential panics, but they can only be reached due to user error in forming strings which can't be converted to CString. I could instead map the CString::new error to a suitable OSStatus, like errSecInvalidData or errSecInvalidEncoding.~ CString::new failures map to errSecConversionError.

AuthorizationExecuteWithPrivileges has been deprecated for years now, but is still usable in Catalina. Adding the deprecated attribute causes extra warning noise in systest.

I went through a few iterations of how to implement the AuthorizationItemSetBuilder and settled on this. I expect it would be a bit simpler using alloc/dealloc, but wanted to avoid manual memory management. It's important that AuthorizationItemSetStorage's names and values fields aren't modified after the builder is consumed, and it's safe from that from a user's perspective.

Some test are ignored, because they require an admin user's name and password. I can look in to updating the CI and enabling these tests if you like.