### PR TITLE
Expose kTLSProtocol13 for TLS 1.3

### DIFF
--- a/security-framework-sys/src/secure_transport.rs
+++ b/security-framework-sys/src/secure_transport.rs
@@ -18,6 +18,7 @@ pub const kTLSProtocol1: SSLProtocol = 4;
 pub const kTLSProtocol11: SSLProtocol = 7;
 pub const kTLSProtocol12: SSLProtocol = 8;
 pub const kDTLSProtocol1: SSLProtocol = 9;
+pub const kTLSProtocol13: SSLProtocol = 10;
 pub const kSSLProtocol2: SSLProtocol = 1;
 pub const kSSLProtocol3Only: SSLProtocol = 3;
 pub const kTLSProtocol1Only: SSLProtocol = 5;

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -401,6 +401,10 @@ impl SslProtocol {
     /// if the peer does not support TLS 1.2.
     pub const TLS12: Self = Self(kTLSProtocol12);
 
+    /// The TLS 1.3 protocol is preferred, though lower versions may be used
+    /// if the peer does not support TLS 1.3.
+    pub const TLS13: Self = Self(kTLSProtocol13);
+
     /// Only the SSL 2.0 protocol is accepted.
     pub const SSL2: Self = Self(kSSLProtocol2);
 


### PR DESCRIPTION
https://developer.apple.com/documentation/security/sslprotocol/ktlsprotocol13?language=objc

macOS 10.14+
iOS 12.2+