### PR TITLE
Support TLS session ticket resumption

### DIFF
--- a/security-framework-sys/src/secure_transport.rs
+++ b/security-framework-sys/src/secure_transport.rs
@@ -266,4 +266,6 @@ extern "C" {
     pub fn SSLSetALPNProtocols(context: SSLContextRef, protocols: CFArrayRef) -> OSStatus;
     #[cfg(feature = "OSX_10_13")]
     pub fn SSLCopyALPNProtocols(context: SSLContextRef, protocols: *mut CFArrayRef) -> OSStatus;
+    #[cfg(feature = "OSX_10_13")]
+    pub fn SSLSetSessionTicketsEnabled(context: SSLContextRef, enabled: Boolean) -> OSStatus;
 }

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -24,12 +24,13 @@ hex = "0.4"
 
 [features]
 alpn = []
+session-tickets = []
 
 OSX_10_9 = ["security-framework-sys/OSX_10_9"]
 OSX_10_10 = ["OSX_10_9", "security-framework-sys/OSX_10_10"]
 OSX_10_11 = ["OSX_10_10", "security-framework-sys/OSX_10_11"]
 OSX_10_12 = ["OSX_10_11", "security-framework-sys/OSX_10_12"]
-OSX_10_13 = ["OSX_10_12", "security-framework-sys/OSX_10_13", "alpn"]
+OSX_10_13 = ["OSX_10_12", "security-framework-sys/OSX_10_13", "alpn", "session-tickets"]
 
 nightly = []
 

--- a/security-framework/src/lib.rs
+++ b/security-framework/src/lib.rs
@@ -35,7 +35,7 @@ macro_rules! p {
     };
 }
 
-#[cfg(all(not(feature = "OSX_10_13"), feature = "alpn"))]
+#[cfg(all(not(feature = "OSX_10_13"), any(feature = "alpn", feature = "session-tickets")))]
 #[macro_use]
 mod dlsym;
 


### PR DESCRIPTION
Initial draft of session ticket resumption support.

There's a bit that probably needs to be fleshed out here:
  - Like ALPN, the relevant APIs for session ticket resumption are also only available on 10.13 and above. I'm currently handling this in a similar way to ALPN by introducing a new feature, but I'm not sure this is a good idea/scalable way to expose features only available on newer versions.
  - The public API for this is a bit convoluted, `pub fn enable_session_tickets(&mut self, address: &[u8]) -> &mut Self`. This is because we need a parameter to pass to `set_peer_id`, and AFAICT, a valid parameter isn't available to us at this abstraction level, without the user passing it in manually.

Fixes #94.