### PR TITLE
Rust 2018 fixes for < OSX_10_13 and ALPN

### DIFF
--- a/security-framework/src/dlsym.rs
+++ b/security-framework/src/dlsym.rs
@@ -10,10 +10,10 @@ use libc;
 macro_rules! dlsym {
     (fn $name:ident($($t:ty),*) -> $ret:ty) => (
         #[allow(bad_style)]
-        static $name: ::dlsym::DlSym<unsafe extern fn($($t),*) -> $ret> =
-            ::dlsym::DlSym {
+        static $name: $crate::dlsym::DlSym<unsafe extern fn($($t),*) -> $ret> =
+            $crate::dlsym::DlSym {
                 name: concat!(stringify!($name), "\0"),
-                addr: ::std::sync::atomic::ATOMIC_USIZE_INIT,
+                addr: ::std::sync::atomic::AtomicUsize::new(0),
                 _marker: ::std::marker::PhantomData,
             };
     )

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -710,7 +710,7 @@ impl SslContext {
     /// Returns the set of protocols selected via ALPN if it succeeded.
     #[cfg(feature = "alpn")]
     pub fn alpn_protocols(&self) -> Result<Vec<String>> {
-        let mut array = ptr::null();
+        let mut array: CFArrayRef = ptr::null();
         unsafe {
             #[cfg(feature = "OSX_10_13")]
             {


### PR DESCRIPTION
Referring to crate root is slightly different in Rust 2018, and it looks like raw pointers need a type specified.