### PR TITLE
Fix examples to work on macOS.

### DIFF
--- a/security-framework/examples/find_internet_password.rs
+++ b/security-framework/examples/find_internet_password.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "mac_os")]
+#[cfg(target_os = "macos")]
 use security_framework::os::macos::keychain::SecKeychain;
-#[cfg(target_os = "mac_os")]
+#[cfg(target_os = "macos")]
 use security_framework::os::macos::passwords::*;
 
 fn main() {
-    #[cfg(target_os = "mac_os")] {
+    #[cfg(target_os = "macos")] {
     let hostname = "example.com";
     let username = "rusty";
     let res = SecKeychain::default().unwrap().find_internet_password(

--- a/security-framework/examples/set_internet_password.rs
+++ b/security-framework/examples/set_internet_password.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "mac_os")]
+#[cfg(target_os = "macos")]
 use security_framework::os::macos::keychain::SecKeychain;
-#[cfg(target_os = "mac_os")]
+#[cfg(target_os = "macos")]
 use security_framework::os::macos::passwords::*;
 
 fn main() {
-    #[cfg(target_os = "mac_os")] {
+    #[cfg(target_os = "macos")] {
     let hostname = "example.com";
     let username = "rusty";
     let password = b"oxidize";


### PR DESCRIPTION
It seems like the `target_os` was set to an invalid value for the examples. Updating this makes them work for my mac system.
