### PR TITLE
Adding current item management methods

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -1,5 +1,3 @@
-use core_foundation_sys::base::{CFTypeRef, OSStatus};
-use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::string::CFStringRef;
 
 extern "C" {
@@ -42,6 +40,4 @@ extern "C" {
     pub static kSecAttrKeyTypeCAST: CFStringRef;
     #[cfg(feature = "OSX_10_9")]
     pub static kSecAttrKeyTypeEC: CFStringRef;
-
-    pub fn SecItemCopyMatching(query: CFDictionaryRef, result: *mut CFTypeRef) -> OSStatus;
 }

--- a/security-framework-sys/src/keychain_item.rs
+++ b/security-framework-sys/src/keychain_item.rs
@@ -1,15 +1,26 @@
 use crate::base::{SecKeychainAttributeList, SecKeychainItemRef};
-use core_foundation_sys::base::{CFTypeID, OSStatus};
+use core_foundation_sys::base::{CFAllocatorRef, CFTypeID, CFTypeRef, OSStatus};
 use core_foundation_sys::dictionary::CFDictionaryRef;
 use std::os::raw::c_void;
 
 extern "C" {
+
+    /// Returns the unique identifier of the opaque type to which a keychain item object belongs.
     pub fn SecKeychainItemGetTypeID() -> CFTypeID;
 
-    pub fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) -> OSStatus;
+    /// Adds one or more items to a keychain.
+    pub fn SecItemAdd(attributes: CFDictionaryRef, result: *mut CFTypeRef) -> OSStatus;
 
+    /// Returns one or more keychain items that match a search query, or copies attributes of specific keychain items.
+    pub fn SecItemCopyMatching(query: CFDictionaryRef, result: *mut CFTypeRef) -> OSStatus;
+
+    /// Modifies items that match a search query.
     pub fn SecItemUpdate(query: CFDictionaryRef, attributesToUpdate: CFDictionaryRef) -> OSStatus;
 
+    /// Deletes items that match a search query.
+    pub fn SecItemDelete(query: CFDictionaryRef) -> OSStatus;
+
+    /// # Legacy API
     pub fn SecKeychainItemModifyAttributesAndData(
         itemRef: SecKeychainItemRef,
         attrList: *const SecKeychainAttributeList,
@@ -21,4 +32,6 @@ extern "C" {
         attrList: *mut SecKeychainAttributeList,
         data: *mut c_void,
     ) -> OSStatus;
+
+    pub fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) -> OSStatus;
 }

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -11,6 +11,7 @@ use core_foundation::string::CFString;
 use core_foundation_sys::base::{CFCopyDescription, CFGetTypeID, CFRelease, CFTypeRef};
 use core_foundation_sys::string::CFStringRef;
 use security_framework_sys::item::*;
+use security_framework_sys::keychain_item::SecItemCopyMatching;
 use std::collections::HashMap;
 use std::fmt;
 use std::ptr;


### PR DESCRIPTION
Regarding the documentation page from apple [here](https://developer.apple.com/documentation/security/keychain_services/keychain_items?language=objc), there is a legacy API and one more up to date
API to manage the items in the keychain.

Here i simply add the missing external C functions.