### PR TITLE
ClientBuilder::add_anchor_certificate

### DIFF
--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -1198,6 +1198,13 @@ impl ClientBuilder {
         self
     }
 
+    /// Add the certificate the set of root certificates to trust
+    /// when verifying the server's certificate.
+    pub fn add_anchor_certificate(&mut self, certs: &SecCertificate) -> &mut Self {
+        self.certs.push(certs.to_owned());
+        self
+    }
+
     /// Specifies whether to trust the built-in certificates in addition
     /// to specified anchor certificates.
     pub fn trust_anchor_certificates_only(&mut self, only: bool) -> &mut Self {


### PR DESCRIPTION
`anchor_certificates` is not flexible enough: it overrides previously
set certificate.  In my wrapper layer there's a function
`add_anchor_certificate`, and it's not possible to imlpement in
current API.

Alternatively we can change `anchor_certificates` to extend the
certificate list, not replace, but it will be technically
semver-incompatible change.