### PR TITLE
Add some more SecKey functionality

### DIFF
--- a/security-framework-sys/src/key.rs
+++ b/security-framework-sys/src/key.rs
@@ -2,8 +2,13 @@ use core_foundation_sys::base::CFTypeID;
 use core_foundation_sys::data::CFDataRef;
 use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::error::CFErrorRef;
+#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+use core_foundation_sys::string::CFStringRef;
 
 use crate::base::SecKeyRef;
+
+#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+pub type SecKeyAlgorithm = CFStringRef;
 
 extern "C" {
     pub fn SecKeyGetTypeID() -> CFTypeID;
@@ -19,4 +24,129 @@ extern "C" {
     pub fn SecKeyCopyExternalRepresentation(key: SecKeyRef, error: *mut CFErrorRef) -> CFDataRef;
     #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
     pub fn SecKeyCopyAttributes(key: SecKeyRef) -> CFDictionaryRef;
+
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    pub fn SecKeyCreateSignature(
+        key: SecKeyRef,
+        algorithm: SecKeyAlgorithm,
+        dataToSign: CFDataRef,
+        error: *mut CFErrorRef,
+    ) -> CFDataRef;
+}
+
+#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+macro_rules! names {
+    ($($i:ident => $x:ident),*) => {
+        extern "C" {
+            $(pub static $x: SecKeyAlgorithm;)*
+        }
+
+        #[non_exhaustive]
+        pub enum Algorithm {
+            $( $i ),*
+        }
+
+        impl From<Algorithm> for SecKeyAlgorithm {
+            fn from(m: Algorithm) -> Self {
+                unsafe { match m {
+                    $( Algorithm::$i => $x, )*
+                } }
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+names! {
+    ECIESEncryptionStandardX963SHA1AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA1AESGCM,
+    ECIESEncryptionStandardX963SHA224AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA224AESGCM,
+    ECIESEncryptionStandardX963SHA256AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA256AESGCM,
+    ECIESEncryptionStandardX963SHA384AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA384AESGCM,
+    ECIESEncryptionStandardX963SHA512AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA512AESGCM,
+
+    ECIESEncryptionStandardVariableIVX963SHA224AESGCM => kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA224AESGCM,
+    ECIESEncryptionStandardVariableIVX963SHA256AESGCM => kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA256AESGCM,
+    ECIESEncryptionStandardVariableIVX963SHA384AESGCM => kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA384AESGCM,
+    ECIESEncryptionStandardVariableIVX963SHA512AESGCM => kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA512AESGCM,
+
+    ECIESEncryptionCofactorVariableIVX963SHA224AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA224AESGCM,
+    ECIESEncryptionCofactorVariableIVX963SHA256AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA256AESGCM,
+    ECIESEncryptionCofactorVariableIVX963SHA384AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA384AESGCM,
+    ECIESEncryptionCofactorVariableIVX963SHA512AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA512AESGCM,
+
+    ECIESEncryptionCofactorX963SHA1AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorX963SHA1AESGCM,
+    ECIESEncryptionCofactorX963SHA224AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorX963SHA224AESGCM,
+    ECIESEncryptionCofactorX963SHA256AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorX963SHA256AESGCM,
+    ECIESEncryptionCofactorX963SHA384AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorX963SHA384AESGCM,
+    ECIESEncryptionCofactorX963SHA512AESGCM => kSecKeyAlgorithmECIESEncryptionCofactorX963SHA512AESGCM,
+
+    ECDSASignatureRFC4754 => kSecKeyAlgorithmECDSASignatureRFC4754,
+
+    ECDSASignatureDigestX962 => kSecKeyAlgorithmECDSASignatureDigestX962,
+    ECDSASignatureDigestX962SHA1 => kSecKeyAlgorithmECDSASignatureDigestX962SHA1,
+    ECDSASignatureDigestX962SHA224 => kSecKeyAlgorithmECDSASignatureDigestX962SHA224,
+    ECDSASignatureDigestX962SHA256 => kSecKeyAlgorithmECDSASignatureDigestX962SHA256,
+    ECDSASignatureDigestX962SHA384 => kSecKeyAlgorithmECDSASignatureDigestX962SHA384,
+    ECDSASignatureDigestX962SHA512 => kSecKeyAlgorithmECDSASignatureDigestX962SHA512,
+
+    ECDSASignatureMessageX962SHA1 => kSecKeyAlgorithmECDSASignatureMessageX962SHA1,
+    ECDSASignatureMessageX962SHA224 => kSecKeyAlgorithmECDSASignatureMessageX962SHA224,
+    ECDSASignatureMessageX962SHA256 => kSecKeyAlgorithmECDSASignatureMessageX962SHA256,
+    ECDSASignatureMessageX962SHA384 => kSecKeyAlgorithmECDSASignatureMessageX962SHA384,
+    ECDSASignatureMessageX962SHA512 => kSecKeyAlgorithmECDSASignatureMessageX962SHA512,
+
+    ECDHKeyExchangeCofactor => kSecKeyAlgorithmECDHKeyExchangeCofactor,
+    ECDHKeyExchangeStandard => kSecKeyAlgorithmECDHKeyExchangeStandard,
+    ECDHKeyExchangeCofactorX963SHA1 => kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA1,
+    ECDHKeyExchangeStandardX963SHA1 => kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA1,
+    ECDHKeyExchangeCofactorX963SHA224 => kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA224,
+    ECDHKeyExchangeCofactorX963SHA256 => kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA256,
+    ECDHKeyExchangeCofactorX963SHA384 => kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA384,
+    ECDHKeyExchangeCofactorX963SHA512 => kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA512,
+    ECDHKeyExchangeStandardX963SHA224 => kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA224,
+    ECDHKeyExchangeStandardX963SHA256 => kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA256,
+    ECDHKeyExchangeStandardX963SHA384 => kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA384,
+    ECDHKeyExchangeStandardX963SHA512 => kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA512,
+
+    RSAEncryptionRaw => kSecKeyAlgorithmRSAEncryptionRaw,
+    RSAEncryptionPKCS1 => kSecKeyAlgorithmRSAEncryptionPKCS1,
+
+    RSAEncryptionOAEPSHA1 => kSecKeyAlgorithmRSAEncryptionOAEPSHA1,
+    RSAEncryptionOAEPSHA224 => kSecKeyAlgorithmRSAEncryptionOAEPSHA224,
+    RSAEncryptionOAEPSHA256 => kSecKeyAlgorithmRSAEncryptionOAEPSHA256,
+    RSAEncryptionOAEPSHA384 => kSecKeyAlgorithmRSAEncryptionOAEPSHA384,
+    RSAEncryptionOAEPSHA512 => kSecKeyAlgorithmRSAEncryptionOAEPSHA512,
+
+    RSAEncryptionOAEPSHA1AESGCM => kSecKeyAlgorithmRSAEncryptionOAEPSHA1AESGCM,
+    RSAEncryptionOAEPSHA224AESGCM => kSecKeyAlgorithmRSAEncryptionOAEPSHA224AESGCM,
+    RSAEncryptionOAEPSHA256AESGCM => kSecKeyAlgorithmRSAEncryptionOAEPSHA256AESGCM,
+    RSAEncryptionOAEPSHA384AESGCM => kSecKeyAlgorithmRSAEncryptionOAEPSHA384AESGCM,
+    RSAEncryptionOAEPSHA512AESGCM => kSecKeyAlgorithmRSAEncryptionOAEPSHA512AESGCM,
+
+    RSASignatureRaw => kSecKeyAlgorithmRSASignatureRaw,
+
+    RSASignatureDigestPKCS1v15Raw => kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw,
+    RSASignatureDigestPKCS1v15SHA1 => kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1,
+    RSASignatureDigestPKCS1v15SHA224 => kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224,
+    RSASignatureDigestPKCS1v15SHA256 => kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,
+    RSASignatureDigestPKCS1v15SHA384 => kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384,
+    RSASignatureDigestPKCS1v15SHA512 => kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512,
+
+    RSASignatureMessagePKCS1v15SHA1 => kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA1,
+    RSASignatureMessagePKCS1v15SHA224 => kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA224,
+    RSASignatureMessagePKCS1v15SHA256 => kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256,
+    RSASignatureMessagePKCS1v15SHA384 => kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA384,
+    RSASignatureMessagePKCS1v15SHA512 => kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512,
+
+    RSASignatureDigestPSSSHA1 => kSecKeyAlgorithmRSASignatureDigestPSSSHA1,
+    RSASignatureDigestPSSSHA224 => kSecKeyAlgorithmRSASignatureDigestPSSSHA224,
+    RSASignatureDigestPSSSHA256 => kSecKeyAlgorithmRSASignatureDigestPSSSHA256,
+    RSASignatureDigestPSSSHA384 => kSecKeyAlgorithmRSASignatureDigestPSSSHA384,
+    RSASignatureDigestPSSSHA512 => kSecKeyAlgorithmRSASignatureDigestPSSSHA512,
+
+    RSASignatureMessagePSSSHA1 => kSecKeyAlgorithmRSASignatureMessagePSSSHA1,
+    RSASignatureMessagePSSSHA224 => kSecKeyAlgorithmRSASignatureMessagePSSSHA224,
+    RSASignatureMessagePSSSHA256 => kSecKeyAlgorithmRSASignatureMessagePSSSHA256,
+    RSASignatureMessagePSSSHA384 => kSecKeyAlgorithmRSASignatureMessagePSSSHA384,
+    RSASignatureMessagePSSSHA512 => kSecKeyAlgorithmRSASignatureMessagePSSSHA512
 }

--- a/security-framework-sys/src/keychain.rs
+++ b/security-framework-sys/src/keychain.rs
@@ -166,4 +166,10 @@ extern "C" {
         keychain: SecKeychainRef,
         newSettings: *const SecKeychainSettings,
     ) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainGetUserInteractionAllowed(state: *mut Boolean) -> OSStatus;
+
+    #[cfg(target_os = "macos")]
+    pub fn SecKeychainSetUserInteractionAllowed(state: Boolean) -> OSStatus;
 }

--- a/security-framework/src/os/macos/keychain.rs
+++ b/security-framework/src/os/macos/keychain.rs
@@ -1,7 +1,7 @@
 //! Keychain support.
 
 use core_foundation::base::{Boolean, TCFType};
-use security_framework_sys::base::SecKeychainRef;
+use security_framework_sys::base::{errSecSuccess, SecKeychainRef};
 use security_framework_sys::keychain::*;
 use std::ffi::CString;
 use std::os::raw::c_void;
@@ -9,7 +9,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr;
 
-use crate::base::Result;
+use crate::base::{Error, Result};
 use crate::cvt;
 use crate::os::macos::access::SecAccess;
 
@@ -72,6 +72,33 @@ impl SecKeychain {
                 self.as_concrete_TypeRef(),
                 &settings.0,
             ))
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    /// Disables the user interface for keychain services functions that
+    /// automatically display a user interface.
+    pub fn disable_user_interaction() -> Result<KeychainUserInteractionLock> {
+        let code = unsafe { SecKeychainSetUserInteractionAllowed(0u8) };
+
+        if code != errSecSuccess {
+            Err(Error::from_code(code))
+        } else {
+            Ok(KeychainUserInteractionLock)
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    /// Indicates whether keychain services functions that normally display a
+    /// user interaction are allowed to do so.
+    pub fn user_interaction_allowed() -> Result<bool> {
+        let mut state: Boolean = 0;
+        let code = unsafe { SecKeychainGetUserInteractionAllowed(&mut state) };
+
+        if code != errSecSuccess {
+            Err(Error::from_code(code))
+        } else {
+            Ok(state != 0)
         }
     }
 }
@@ -180,6 +207,18 @@ impl KeychainSettings {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[must_use = "The user interaction is disabled for the lifetime of the returned object"]
+/// Automatically re-enables user interaction.
+pub struct KeychainUserInteractionLock;
+
+#[cfg(target_os = "macos")]
+impl Drop for KeychainUserInteractionLock {
+    fn drop(&mut self) {
+        unsafe { SecKeychainSetUserInteractionAllowed(1u8) };
+    }
+}
+
 #[cfg(test)]
 mod test {
     use tempdir::TempDir;
@@ -196,5 +235,15 @@ mod test {
             .unwrap();
 
         keychain.set_settings(&KeychainSettings::new()).unwrap();
+    }
+
+    #[test]
+    fn disable_user_interaction() {
+        assert!(SecKeychain::user_interaction_allowed().unwrap());
+        {
+            let _lock = SecKeychain::disable_user_interaction().unwrap();
+            assert!(!SecKeychain::user_interaction_allowed().unwrap());
+        }
+        assert!(SecKeychain::user_interaction_allowed().unwrap());
     }
 }


### PR DESCRIPTION
There's plenty more to add relating to SecKey. This at least enables me to verify that an item in the keychain is accessible by attempting to use it to create a signature while having user interaction disabled.

I tried to make the Algorithm enum a bit less horrific by using a macro, but the approach I attempted involved concat_ident which is a nightly only feature. I'll see if there's a nicer way of doing this if you don't know of one yourself.