### PR TITLE
Use log crate to log certificate evaluation

### DIFF
--- a/security-framework-sys/src/trust.rs
+++ b/security-framework-sys/src/trust.rs
@@ -2,6 +2,8 @@ use crate::base::SecCertificateRef;
 use crate::base::SecKeyRef;
 use core_foundation_sys::array::CFArrayRef;
 use core_foundation_sys::base::{Boolean, CFIndex, CFTypeID, CFTypeRef, OSStatus};
+use core_foundation_sys::error::CFErrorRef;
+
 pub type SecTrustResultType = u32;
 
 pub const kSecTrustResultInvalid: SecTrustResultType = 0;
@@ -29,6 +31,7 @@ extern "C" {
         anchorCertificatesOnly: Boolean,
     ) -> OSStatus;
     pub fn SecTrustEvaluate(trust: SecTrustRef, result: *mut SecTrustResultType) -> OSStatus;
+    pub fn SecTrustEvaluateWithError(trust: SecTrustRef, error: *mut CFErrorRef) -> bool;
     pub fn SecTrustCreateWithCertificates(
         certificates: CFTypeRef,
         policies: CFTypeRef,

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -19,10 +19,12 @@ core-foundation = "0.9"
 core-foundation-sys = "0.8"
 bitflags = "1.2.1"
 libc = "0.2.68"
+log = "0.4.14"
 
 [dev-dependencies]
 tempdir = "0.3.7"
 hex = "0.4.2"
+env_logger = "0.8.3"
 
 [features]
 default = ["OSX_10_9"]

--- a/security-framework/src/os/macos/secure_transport.rs
+++ b/security-framework/src/os/macos/secure_transport.rs
@@ -259,8 +259,7 @@ mod test {
         assert!(stream.server_auth_completed());
         let mut peer_trust = p!(stream.context().peer_trust2()).unwrap();
         p!(peer_trust.set_anchor_certificates(&[certificate()]));
-        let result = p!(peer_trust.evaluate());
-        assert!(result.success());
+        p!(peer_trust.evaluate_new());
 
         let mut stream = p!(stream.handshake());
         p!(stream.write_all(b"hello world!"));
@@ -300,6 +299,8 @@ mod test {
 
     #[test]
     fn client_bad_cert() {
+        let _ = env_logger::try_init();
+
         let listener = p!(TcpListener::bind("localhost:0"));
         let port = p!(listener.local_addr()).port();
 


### PR DESCRIPTION
`Error` cannot be extended to store defailed error information, so
log it to be able to obtain this information.

```
$ RUST_LOG=debug cargo test --lib client_bad_cert
...
[2021-02-23T10:14:25Z WARN  security_framework::trust] SecTrust::evaluate_new failed: “foobar.com” certificate is not trusted
test os::macos::secure_transport::test::client_bad_cert ... ok
```