### PR TITLE
Add Authorization::execute_with_privileges

### DIFF
--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -536,11 +536,7 @@ impl<'a> Authorization {
             )
         };
 
-        if status != sys::errAuthorizationSuccess {
-            Err(Error::from(status))
-        } else {
-            Ok(())
-        }
+        crate::cvt(status)
     }
 }
 

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -17,8 +17,7 @@ use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 use std::{
     convert::TryFrom,
-    ffi::{CStr, CString, OsStr},
-    path::Path,
+    ffi::{CStr, CString},
 };
 use std::{convert::TryInto, marker::PhantomData};
 use sys::AuthorizationExternalForm;
@@ -509,9 +508,9 @@ impl<'a> Authorization {
         flags: Flags,
     ) -> Result<()>
     where
-        P: AsRef<Path>,
+        P: AsRef<std::path::Path>,
         I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
+        S: AsRef<std::ffi::OsStr>,
     {
         // OsStr::as_bytes
         use std::os::unix::ffi::OsStrExt as _;


### PR DESCRIPTION
This PR adds Authorization::execute_with_privileges function.

I know that it's considered deprecated but it is required for one of our projects and is actually quite useful so I thought to make a PR into the upstream. Otherwise it requires to fiddle around directly with security-framework-sys and low level API to call the `AuthorizationExecuteWithPrivileges`.
