### PR TITLE
Add bindings for SecKeychainCopyDomainDefault

### DIFF
--- a/security-framework-sys/src/keychain.rs
+++ b/security-framework-sys/src/keychain.rs
@@ -86,9 +86,22 @@ pub enum SecAuthenticationType {
     Any = 0,
 }
 
+#[repr(i32)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SecPreferencesDomain {
+    User = 0,
+    System = 1,
+    Common = 2,
+    Dynamic = 3,
+}
+
 extern "C" {
     pub fn SecKeychainGetTypeID() -> CFTypeID;
     pub fn SecKeychainCopyDefault(keychain: *mut SecKeychainRef) -> OSStatus;
+    pub fn SecKeychainCopyDomainDefault(
+        domain: SecPreferencesDomain,
+        keychain: *mut SecKeychainRef,
+    ) -> OSStatus;
     pub fn SecKeychainCreate(
         pathName: *const c_char,
         passwordLength: c_uint,

--- a/security-framework/src/os/macos/keychain.rs
+++ b/security-framework/src/os/macos/keychain.rs
@@ -34,6 +34,16 @@ impl SecKeychain {
         }
     }
 
+    /// Creates a `SecKeychain` object corresponding to the user's default
+    /// keychain for the given domain.
+    pub fn default_for_domain(domain: SecPreferencesDomain) -> Result<Self> {
+        unsafe {
+            let mut keychain = ptr::null_mut();
+            cvt(SecKeychainCopyDomainDefault(domain, &mut keychain))?;
+            Ok(Self::wrap_under_create_rule(keychain))
+        }
+    }
+
     /// Opens a keychain from a file.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path_name = path.as_ref().as_os_str().as_bytes();


### PR DESCRIPTION
See https://developer.apple.com/documentation/security/1401993-seckeychaincopydomaindefault?language=objc.

This is super similar to `SecKeychainCopyDefault` that is used in `SecKeychain::default` but it takes an additional domain.