### PR TITLE
Fix missing re-export for `SecPreferencesDomain`

### DIFF
--- a/security-framework/src/os/macos/keychain.rs
+++ b/security-framework/src/os/macos/keychain.rs
@@ -13,6 +13,8 @@ use crate::base::{Error, Result};
 use crate::cvt;
 use crate::os::macos::access::SecAccess;
 
+pub use security_framework_sys::keychain::SecPreferencesDomain;
+
 declare_TCFType! {
     /// A type representing a keychain.
     SecKeychain, SecKeychainRef


### PR DESCRIPTION
Forgot to re-export the symbol in #126, do that here so that users of `security-framework` don’t have to depend on `security-framework-sys` to use this function. Sorry for the noise.