### PR TITLE
New Item search features

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -9,6 +9,7 @@ extern "C" {
     pub static kSecClassIdentity: CFStringRef;
 
     pub static kSecMatchLimit: CFStringRef;
+    pub static kSecMatchLimitAll: CFStringRef;
 
     pub static kSecReturnData: CFStringRef;
     pub static kSecReturnAttributes: CFStringRef;
@@ -40,4 +41,7 @@ extern "C" {
     pub static kSecAttrKeyTypeCAST: CFStringRef;
     #[cfg(feature = "OSX_10_9")]
     pub static kSecAttrKeyTypeEC: CFStringRef;
+
+    pub static kSecAttrAccessGroup: CFStringRef;
+    pub static kSecAttrAccessGroupToken: CFStringRef;
 }


### PR DESCRIPTION
This commit adds two new features to the Item search:

* Support for kSecMatchLimitAll. Previously, this library only allowed
searching for a single item, or for a specific number of items. This
feature allows all items available to be returned.

* Support for kSecAttrAccessGroup, specifically set to
kSecAttrAccessGroupToken. This allows retrieving items that have been
retrieved from a token, such as a smart card, via a CryptoTokenKit
provider.


Note that the current implementation for `kSecMatchLimitAll` is a breaking change. I think the new implementation is fairly clean and matches the feature for specifying the item class, but if you don't want a breaking change I'm happy to discuss alternatives.