### PR TITLE
Expose SecKey.h functionality on macOS

### DIFF
--- a/security-framework-sys/src/key.rs
+++ b/security-framework-sys/src/key.rs
@@ -2,12 +2,12 @@ use core_foundation_sys::base::CFTypeID;
 use core_foundation_sys::data::CFDataRef;
 use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::error::CFErrorRef;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 use core_foundation_sys::string::CFStringRef;
 
 use crate::base::SecKeyRef;
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 pub type SecKeyAlgorithm = CFStringRef;
 
 extern "C" {
@@ -20,12 +20,12 @@ extern "C" {
         error: *mut CFErrorRef,
     ) -> SecKeyRef;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
     pub fn SecKeyCopyExternalRepresentation(key: SecKeyRef, error: *mut CFErrorRef) -> CFDataRef;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
     pub fn SecKeyCopyAttributes(key: SecKeyRef) -> CFDictionaryRef;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
     pub fn SecKeyCreateSignature(
         key: SecKeyRef,
         algorithm: SecKeyAlgorithm,
@@ -34,7 +34,7 @@ extern "C" {
     ) -> CFDataRef;
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 macro_rules! names {
     ($($i:ident => $x:ident),*) => {
         extern "C" {
@@ -58,7 +58,7 @@ macro_rules! names {
     }
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 names! {
     ECIESEncryptionStandardX963SHA1AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA1AESGCM,
     ECIESEncryptionStandardX963SHA224AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA224AESGCM,

--- a/security-framework/src/key.rs
+++ b/security-framework/src/key.rs
@@ -1,19 +1,19 @@
 //! Encryption key support
 
 use core_foundation::base::TCFType;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 use core_foundation::base::ToVoid;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 use core_foundation::data::CFData;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 use core_foundation::dictionary::CFDictionary;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 use core_foundation::error::{CFError, CFErrorRef};
 use security_framework_sys::base::SecKeyRef;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 pub use security_framework_sys::key::Algorithm;
 use security_framework_sys::key::SecKeyGetTypeID;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
 use security_framework_sys::key::{
     SecKeyCopyAttributes, SecKeyCopyExternalRepresentation, SecKeyCreateSignature,
 };
@@ -29,14 +29,14 @@ unsafe impl Sync for SecKey {}
 unsafe impl Send for SecKey {}
 
 impl SecKey {
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
     /// Translates to SecKeyCopyAttributes
     pub fn attributes(&self) -> CFDictionary {
         let pka = unsafe { SecKeyCopyAttributes(self.to_void() as _) };
         unsafe { CFDictionary::wrap_under_create_rule(pka) }
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
     /// Translates to SecKeyCopyExternalRepresentation
     pub fn external_representation(&self) -> Option<CFData> {
         let mut error: CFErrorRef = ::std::ptr::null_mut();
@@ -47,7 +47,7 @@ impl SecKey {
         Some(unsafe { CFData::wrap_under_create_rule(data) })
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "macos"))]
     /// Creates the cryptographic signature for a block of data using a private
     /// key and specified algorithm.
     pub fn create_signature(


### PR DESCRIPTION
SecKey.h functionality has been supported on macOS since 10.12.

https://opensource.apple.com/source/Security/Security-58286.41.2/keychain/SecKey.h.auto.html