### PR TITLE
Add initial support for code signing services

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           command: test
           args: --all-features
+        continue-on-error: ${{ matrix.rust == 'nightly' }}
 
       - name: Check default features
         uses: actions-rs/cargo@v1

--- a/security-framework-sys/src/code_signing.rs
+++ b/security-framework-sys/src/code_signing.rs
@@ -1,9 +1,8 @@
-use core_foundation_sys::{
-    base::{CFTypeID, OSStatus},
-    dictionary::CFDictionaryRef,
-    string::CFStringRef,
-    url::CFURLRef,
-};
+use core_foundation_sys::base::CFTypeID;
+use core_foundation_sys::base::OSStatus;
+use core_foundation_sys::dictionary::CFDictionaryRef;
+use core_foundation_sys::string::CFStringRef;
+use core_foundation_sys::url::CFURLRef;
 
 pub enum OpaqueSecRequirementRef {}
 pub type SecRequirementRef = *mut OpaqueSecRequirementRef;
@@ -31,7 +30,8 @@ pub const kSecCSUseSoftwareSigningCert: SecCSFlags = 1 << 10;
 pub const kSecCSValidatePEH: SecCSFlags = 1 << 11;
 pub const kSecCSSingleThreaded: SecCSFlags = 1 << 12;
 // 13 - 15 are unused
-pub const kSecCSAllowNetworkAccess: SecCSFlags = 1 << 16;
+// This is only available in macOS 11.3:
+// pub const kSecCSAllowNetworkAccess: SecCSFlags = 1 << 16;
 // 17 - 25 are unused
 pub const kSecCSQuickCheck: SecCSFlags = 1 << 26;
 pub const kSecCSCheckTrustedAnchors: SecCSFlags = 1 << 27;

--- a/security-framework-sys/src/code_signing.rs
+++ b/security-framework-sys/src/code_signing.rs
@@ -1,0 +1,78 @@
+use core_foundation_sys::{
+    base::{CFTypeID, OSStatus},
+    dictionary::CFDictionaryRef,
+    string::CFStringRef,
+    url::CFURLRef,
+};
+
+pub enum OpaqueSecRequirementRef {}
+pub type SecRequirementRef = *mut OpaqueSecRequirementRef;
+
+pub enum OpaqueSecCodeRef {}
+pub type SecCodeRef = *mut OpaqueSecCodeRef;
+
+pub enum OpaqueSecStaticCodeRef {}
+pub type SecStaticCodeRef = *mut OpaqueSecStaticCodeRef;
+
+pub type SecCSFlags = u32;
+pub const kSecCSConsiderExpiration: SecCSFlags = 1 << 31;
+pub const kSecCSEnforceRevocationChecks: SecCSFlags = 1 << 30;
+pub const kSecCSNoNetworkAccess: SecCSFlags = 1 << 29;
+pub const kSecCSReportProgress: SecCSFlags = 1 << 28;
+pub const kSecCSCheckTrustedAnchors: SecCSFlags = 1 << 27;
+pub const kSecCSQuickCheck: SecCSFlags = 1 << 26;
+
+extern "C" {
+    pub static kSecGuestAttributeArchitecture: CFStringRef;
+    pub static kSecGuestAttributeAudit: CFStringRef;
+    pub static kSecGuestAttributeCanonical: CFStringRef;
+    pub static kSecGuestAttributeDynamicCode: CFStringRef;
+    pub static kSecGuestAttributeDynamicCodeInfoPlist: CFStringRef;
+    pub static kSecGuestAttributeHash: CFStringRef;
+    pub static kSecGuestAttributeMachPort: CFStringRef;
+    pub static kSecGuestAttributePid: CFStringRef;
+    pub static kSecGuestAttributeSubarchitecture: CFStringRef;
+
+    pub fn SecCodeGetTypeID() -> CFTypeID;
+    pub fn SecStaticCodeGetTypeID() -> CFTypeID;
+    pub fn SecRequirementGetTypeID() -> CFTypeID;
+
+    pub fn SecCodeCheckValidity(
+        code: SecCodeRef,
+        flags: SecCSFlags,
+        requirement: SecRequirementRef,
+    ) -> OSStatus;
+
+    pub fn SecCodeCopyGuestWithAttributes(
+        host: SecCodeRef,
+        attrs: CFDictionaryRef,
+        flags: SecCSFlags,
+        guest: *mut SecCodeRef,
+    ) -> OSStatus;
+
+    pub fn SecCodeCopyPath(
+        code: SecStaticCodeRef,
+        flags: SecCSFlags,
+        path: *mut CFURLRef,
+    ) -> OSStatus;
+
+    pub fn SecCodeCopySelf(flags: SecCSFlags, out: *mut SecCodeRef) -> OSStatus;
+
+    pub fn SecRequirementCreateWithString(
+        text: CFStringRef,
+        flags: SecCSFlags,
+        requirement: *mut SecRequirementRef,
+    ) -> OSStatus;
+
+    pub fn SecStaticCodeCheckValidity(
+        code: SecStaticCodeRef,
+        flags: SecCSFlags,
+        requirement: SecRequirementRef,
+    ) -> OSStatus;
+
+    pub fn SecStaticCodeCreateWithPath(
+        path: CFURLRef,
+        flags: SecCSFlags,
+        code: *mut SecStaticCodeRef,
+    ) -> OSStatus;
+}

--- a/security-framework-sys/src/code_signing.rs
+++ b/security-framework-sys/src/code_signing.rs
@@ -15,12 +15,30 @@ pub enum OpaqueSecStaticCodeRef {}
 pub type SecStaticCodeRef = *mut OpaqueSecStaticCodeRef;
 
 pub type SecCSFlags = u32;
-pub const kSecCSConsiderExpiration: SecCSFlags = 1 << 31;
-pub const kSecCSEnforceRevocationChecks: SecCSFlags = 1 << 30;
-pub const kSecCSNoNetworkAccess: SecCSFlags = 1 << 29;
-pub const kSecCSReportProgress: SecCSFlags = 1 << 28;
-pub const kSecCSCheckTrustedAnchors: SecCSFlags = 1 << 27;
+pub const kSecCSCheckAllArchitectures: SecCSFlags = 1 << 0;
+pub const kSecCSDoNotValidateExecutable: SecCSFlags = 1 << 1;
+pub const kSecCSDoNotValidateResources: SecCSFlags = 1 << 2;
+pub const kSecCSBasicValidateOnly: SecCSFlags =
+    kSecCSDoNotValidateExecutable | kSecCSDoNotValidateResources;
+pub const kSecCSCheckNestedCode: SecCSFlags = 1 << 3;
+pub const kSecCSStrictValidate: SecCSFlags = 1 << 4;
+pub const kSecCSFullReport: SecCSFlags = 1 << 5;
+pub const kSecCSCheckGatekeeperArchitectures: SecCSFlags = (1 << 6) | kSecCSCheckAllArchitectures;
+pub const kSecCSRestrictSymlinks: SecCSFlags = 1 << 7;
+pub const kSecCSRestrictToAppLike: SecCSFlags = 1 << 8;
+pub const kSecCSRestrictSidebandData: SecCSFlags = 1 << 9;
+pub const kSecCSUseSoftwareSigningCert: SecCSFlags = 1 << 10;
+pub const kSecCSValidatePEH: SecCSFlags = 1 << 11;
+pub const kSecCSSingleThreaded: SecCSFlags = 1 << 12;
+// 13 - 15 are unused
+pub const kSecCSAllowNetworkAccess: SecCSFlags = 1 << 16;
+// 17 - 25 are unused
 pub const kSecCSQuickCheck: SecCSFlags = 1 << 26;
+pub const kSecCSCheckTrustedAnchors: SecCSFlags = 1 << 27;
+pub const kSecCSReportProgress: SecCSFlags = 1 << 28;
+pub const kSecCSNoNetworkAccess: SecCSFlags = 1 << 29;
+pub const kSecCSEnforceRevocationChecks: SecCSFlags = 1 << 30;
+pub const kSecCSConsiderExpiration: SecCSFlags = 1 << 31;
 
 extern "C" {
     pub static kSecGuestAttributeArchitecture: CFStringRef;

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -16,6 +16,8 @@ pub mod certificate;
 pub mod certificate_oids;
 pub mod cipher_suite;
 #[cfg(target_os = "macos")]
+pub mod code_signing;
+#[cfg(target_os = "macos")]
 pub mod digest_transform;
 #[cfg(target_os = "macos")]
 pub mod encrypt_transform;

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -721,7 +721,7 @@ mod tests {
         use std::io::{self, BufRead};
         for line in io::BufReader::new(file).lines() {
             if let Ok(s) = line {
-                // println!("{}", s);
+                println!("{}", s);
             }
         }
 

--- a/security-framework/src/os/macos/code_signing.rs
+++ b/security-framework/src/os/macos/code_signing.rs
@@ -12,17 +12,17 @@ use core_foundation::{
 };
 use libc::pid_t;
 use security_framework_sys::code_signing::{
-    kSecCSAllowNetworkAccess, kSecCSBasicValidateOnly, kSecCSCheckAllArchitectures,
-    kSecCSCheckGatekeeperArchitectures, kSecCSCheckNestedCode, kSecCSCheckTrustedAnchors,
-    kSecCSConsiderExpiration, kSecCSDoNotValidateExecutable, kSecCSDoNotValidateResources,
-    kSecCSEnforceRevocationChecks, kSecCSFullReport, kSecCSNoNetworkAccess, kSecCSQuickCheck,
-    kSecCSReportProgress, kSecCSRestrictSidebandData, kSecCSRestrictSymlinks,
-    kSecCSRestrictToAppLike, kSecCSSingleThreaded, kSecCSStrictValidate,
-    kSecCSUseSoftwareSigningCert, kSecCSValidatePEH, kSecGuestAttributeAudit,
-    kSecGuestAttributePid, SecCodeCheckValidity, SecCodeCopyGuestWithAttributes, SecCodeCopyPath,
-    SecCodeCopySelf, SecCodeGetTypeID, SecCodeRef, SecRequirementCreateWithString,
-    SecRequirementGetTypeID, SecRequirementRef, SecStaticCodeCheckValidity,
-    SecStaticCodeCreateWithPath, SecStaticCodeGetTypeID, SecStaticCodeRef,
+    kSecCSBasicValidateOnly, kSecCSCheckAllArchitectures, kSecCSCheckGatekeeperArchitectures,
+    kSecCSCheckNestedCode, kSecCSCheckTrustedAnchors, kSecCSConsiderExpiration,
+    kSecCSDoNotValidateExecutable, kSecCSDoNotValidateResources, kSecCSEnforceRevocationChecks,
+    kSecCSFullReport, kSecCSNoNetworkAccess, kSecCSQuickCheck, kSecCSReportProgress,
+    kSecCSRestrictSidebandData, kSecCSRestrictSymlinks, kSecCSRestrictToAppLike,
+    kSecCSSingleThreaded, kSecCSStrictValidate, kSecCSUseSoftwareSigningCert, kSecCSValidatePEH,
+    kSecGuestAttributeAudit, kSecGuestAttributePid, SecCodeCheckValidity,
+    SecCodeCopyGuestWithAttributes, SecCodeCopyPath, SecCodeCopySelf, SecCodeGetTypeID, SecCodeRef,
+    SecRequirementCreateWithString, SecRequirementGetTypeID, SecRequirementRef,
+    SecStaticCodeCheckValidity, SecStaticCodeCreateWithPath, SecStaticCodeGetTypeID,
+    SecStaticCodeRef,
 };
 
 use crate::{cvt, Result};
@@ -80,9 +80,6 @@ bitflags::bitflags! {
 
         /// Apple have not documented this flag.
         const SINGLE_THREADED = kSecCSSingleThreaded;
-
-        /// Apple have not documented this flag.
-        const ALLOW_NETWORK_ACCESS = kSecCSAllowNetworkAccess;
 
         /// Apple have not documented this flag.
         const QUICK_CHECK = kSecCSQuickCheck;

--- a/security-framework/src/os/macos/code_signing.rs
+++ b/security-framework/src/os/macos/code_signing.rs
@@ -12,8 +12,13 @@ use core_foundation::{
 };
 use libc::pid_t;
 use security_framework_sys::code_signing::{
-    kSecCSCheckTrustedAnchors, kSecCSConsiderExpiration, kSecCSEnforceRevocationChecks,
-    kSecCSNoNetworkAccess, kSecCSQuickCheck, kSecCSReportProgress, kSecGuestAttributeAudit,
+    kSecCSAllowNetworkAccess, kSecCSBasicValidateOnly, kSecCSCheckAllArchitectures,
+    kSecCSCheckGatekeeperArchitectures, kSecCSCheckNestedCode, kSecCSCheckTrustedAnchors,
+    kSecCSConsiderExpiration, kSecCSDoNotValidateExecutable, kSecCSDoNotValidateResources,
+    kSecCSEnforceRevocationChecks, kSecCSFullReport, kSecCSNoNetworkAccess, kSecCSQuickCheck,
+    kSecCSReportProgress, kSecCSRestrictSidebandData, kSecCSRestrictSymlinks,
+    kSecCSRestrictToAppLike, kSecCSSingleThreaded, kSecCSStrictValidate,
+    kSecCSUseSoftwareSigningCert, kSecCSValidatePEH, kSecGuestAttributeAudit,
     kSecGuestAttributePid, SecCodeCheckValidity, SecCodeCopyGuestWithAttributes, SecCodeCopyPath,
     SecCodeCopySelf, SecCodeGetTypeID, SecCodeRef, SecRequirementCreateWithString,
     SecRequirementGetTypeID, SecRequirementRef, SecStaticCodeCheckValidity,
@@ -23,18 +28,79 @@ use security_framework_sys::code_signing::{
 use crate::{cvt, Result};
 
 bitflags::bitflags! {
+
     /// Values that can be used in the flags parameter to most code signing
     /// functions.
     pub struct Flags: u32 {
+        /// Use the default behaviour.
         const NONE = 0;
 
-        /// Consider expired certificates invalid.
-        const CONSIDER_EXPIRATION = kSecCSConsiderExpiration;
-        const ENFORCE_REVOCATION_CHECKS = kSecCSEnforceRevocationChecks;
-        const NO_NETWORK_ACCESS = kSecCSNoNetworkAccess;
-        const REPORT_PROGRESS = kSecCSReportProgress;
-        const CHECK_TRUSTED_ANCHORS = kSecCSCheckTrustedAnchors;
+        /// For multi-architecture (universal) Mach-O programs, validate all
+        /// architectures included.
+        const CHECK_ALL_ARCHITECTURES = kSecCSCheckAllArchitectures;
+
+        /// Do not validate the contents of the main executable.
+        const DO_NOT_VALIDATE_EXECUTABLE = kSecCSDoNotValidateExecutable;
+
+        /// Do not validate the presence and contents of all bundle resources
+        /// if any.
+        const DO_NOT_VALIDATE_RESOURCES = kSecCSDoNotValidateResources;
+
+        /// Do not validate either the main executable or the bundle resources,
+        /// if any.
+        const BASIC_VALIDATE_ONLY = kSecCSBasicValidateOnly;
+
+        /// For code in bundle form, locate and recursively check embedded code.
+        const CHECK_NESTED_CODE = kSecCSCheckNestedCode;
+
+        /// Perform additional checks to ensure the validity of code in bundle
+        /// form.
+        const STRICT_VALIDATE = kSecCSStrictValidate;
+
+        /// Apple have not documented this flag.
+        const FULL_REPORT = kSecCSFullReport;
+
+        /// Apple have not documented this flag.
+        const CHECK_GATEKEEPER_ARCHITECTURES = kSecCSCheckGatekeeperArchitectures;
+
+        /// Apple have not documented this flag.
+        const RESTRICT_SYMLINKS = kSecCSRestrictSymlinks;
+
+        /// Apple have not documented this flag.
+        const RESTRICT_TO_APP_LIKE = kSecCSRestrictToAppLike;
+
+        /// Apple have not documented this flag.
+        const RESTRICT_SIDEBAND_DATA = kSecCSRestrictSidebandData;
+
+        /// Apple have not documented this flag.
+        const USE_SOFTWARE_SIGNING_CERT = kSecCSUseSoftwareSigningCert;
+
+        /// Apple have not documented this flag.
+        const VALIDATE_PEH = kSecCSValidatePEH;
+
+        /// Apple have not documented this flag.
+        const SINGLE_THREADED = kSecCSSingleThreaded;
+
+        /// Apple have not documented this flag.
+        const ALLOW_NETWORK_ACCESS = kSecCSAllowNetworkAccess;
+
+        /// Apple have not documented this flag.
         const QUICK_CHECK = kSecCSQuickCheck;
+
+        /// Apple have not documented this flag.
+        const CHECK_TRUSTED_ANCHORS = kSecCSCheckTrustedAnchors;
+
+        /// Apple have not documented this flag.
+        const REPORT_PROGRESS = kSecCSReportProgress;
+
+        /// Apple have not documented this flag.
+        const NO_NETWORK_ACCESS = kSecCSNoNetworkAccess;
+
+        /// Apple have not documented this flag.
+        const ENFORCE_REVOCATION_CHECKS = kSecCSEnforceRevocationChecks;
+
+        /// Apple have not documented this flag.
+        const CONSIDER_EXPIRATION = kSecCSConsiderExpiration;
     }
 }
 

--- a/security-framework/src/os/macos/code_signing.rs
+++ b/security-framework/src/os/macos/code_signing.rs
@@ -3,11 +3,11 @@
 use std::{mem::MaybeUninit, str::FromStr};
 
 use core_foundation::{
-    base::{TCFType, TCFTypeRef},
+    base::{TCFType, TCFTypeRef, ToVoid},
     data::CFDataRef,
     dictionary::CFMutableDictionary,
     number::CFNumber,
-    string::CFString,
+    string::{CFString, CFStringRef},
     url::CFURL,
 };
 use libc::pid_t;
@@ -62,16 +62,21 @@ impl GuestAttributes {
     // - sub-architecture
 
     /// The guest's audit token.
-    pub fn audit_token(&mut self, token: CFDataRef) {
+    pub fn set_audit_token(&mut self, token: CFDataRef) {
         let key = unsafe { CFString::wrap_under_get_rule(kSecGuestAttributeAudit) };
         self.inner.add(&key.as_CFTypeRef(), &token.as_void_ptr());
     }
 
     /// The guest's pid.
-    pub fn pid(&mut self, pid: pid_t) {
+    pub fn set_pid(&mut self, pid: pid_t) {
         let key = unsafe { CFString::wrap_under_get_rule(kSecGuestAttributePid) };
         let pid = CFNumber::from(pid);
         self.inner.add(&key.as_CFTypeRef(), &pid.as_CFTypeRef());
+    }
+
+    /// Support for arbirtary guest attributes.
+    pub fn set_other<V: ToVoid<V>>(&mut self, key: CFStringRef, value: V) {
+        self.inner.add(&key.as_void_ptr(), &value.to_void());
     }
 }
 

--- a/security-framework/src/os/macos/code_signing.rs
+++ b/security-framework/src/os/macos/code_signing.rs
@@ -1,0 +1,276 @@
+//! Code signing services.
+
+use std::{mem::MaybeUninit, str::FromStr};
+
+use core_foundation::{
+    base::{TCFType, TCFTypeRef},
+    data::CFDataRef,
+    dictionary::CFMutableDictionary,
+    number::CFNumber,
+    string::CFString,
+    url::CFURL,
+};
+use libc::pid_t;
+use security_framework_sys::{
+    base::errSecSuccess,
+    code_signing::{
+        kSecCSCheckTrustedAnchors, kSecCSConsiderExpiration, kSecCSEnforceRevocationChecks,
+        kSecCSNoNetworkAccess, kSecCSQuickCheck, kSecCSReportProgress, kSecGuestAttributeAudit,
+        kSecGuestAttributePid, SecCodeCheckValidity, SecCodeCopyGuestWithAttributes,
+        SecCodeCopyPath, SecCodeCopySelf, SecCodeGetTypeID, SecCodeRef,
+        SecRequirementCreateWithString, SecRequirementGetTypeID, SecRequirementRef,
+        SecStaticCodeCheckValidity, SecStaticCodeCreateWithPath, SecStaticCodeGetTypeID,
+        SecStaticCodeRef,
+    },
+};
+
+use crate::{cvt, Result};
+
+bitflags::bitflags! {
+    /// Values that can be used in the flags parameter to most code signing
+    /// functions.
+    pub struct Flags: u32 {
+        const NONE = 0;
+
+        /// Consider expired certificates invalid.
+        const CONSIDER_EXPIRATION = kSecCSConsiderExpiration;
+        const ENFORCE_REVOCATION_CHECKS = kSecCSEnforceRevocationChecks;
+        const NO_NETWORK_ACCESS = kSecCSNoNetworkAccess;
+        const REPORT_PROGRESS = kSecCSReportProgress;
+        const CHECK_TRUSTED_ANCHORS = kSecCSCheckTrustedAnchors;
+        const QUICK_CHECK = kSecCSQuickCheck;
+    }
+}
+
+impl Default for Flags {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+/// A helper to create guest attributes, which are normally passed as a
+/// `CFDictionary` with varying types.
+pub struct GuestAttributes {
+    inner: CFMutableDictionary,
+}
+
+impl GuestAttributes {
+    // Not implemented:
+    // - architecture
+    // - canonical
+    // - dynamic code
+    // - dynamic code info plist
+    // - hash
+    // - mach port
+    // - sub-architecture
+
+    /// The guest's audit token.
+    pub fn audit_token(&mut self, token: CFDataRef) {
+        let key = unsafe { CFString::wrap_under_get_rule(kSecGuestAttributeAudit) };
+        self.inner.add(&key.as_CFTypeRef(), &token.as_void_ptr());
+    }
+
+    /// The guest's pid.
+    pub fn pid(&mut self, pid: pid_t) {
+        let key = unsafe { CFString::wrap_under_get_rule(kSecGuestAttributePid) };
+        let pid = CFNumber::from(pid);
+        self.inner.add(&key.as_CFTypeRef(), &pid.as_CFTypeRef());
+    }
+}
+
+declare_TCFType! {
+    /// A code object representing signed code running on the system.
+    SecRequirement, SecRequirementRef
+}
+impl_TCFType!(SecRequirement, SecRequirementRef, SecRequirementGetTypeID);
+
+impl FromStr for SecRequirement {
+    type Err = crate::base::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let text = CFString::new(s);
+        let mut requirement = MaybeUninit::uninit();
+
+        unsafe {
+            cvt(SecRequirementCreateWithString(
+                text.as_concrete_TypeRef(),
+                0,
+                requirement.as_mut_ptr(),
+            ))?;
+
+            Ok(Self::wrap_under_create_rule(requirement.assume_init()))
+        }
+    }
+}
+
+declare_TCFType! {
+    /// A code object representing signed code running on the system.
+    SecCode, SecCodeRef
+}
+impl_TCFType!(SecCode, SecCodeRef, SecCodeGetTypeID);
+
+impl SecCode {
+    /// Retrieves the code object for the code making the call.
+    pub fn for_self(flags: Flags) -> Self {
+        let mut code = MaybeUninit::uninit();
+
+        let status = unsafe { SecCodeCopySelf(flags.bits(), code.as_mut_ptr()) };
+
+        if status != errSecSuccess {
+            panic!("TODO: error");
+        }
+
+        unsafe { Self::wrap_under_create_rule(code.assume_init()) }
+    }
+
+    /// Performs dynamic validation of signed code.
+    pub fn check_validity(&self, flags: Flags, requirement: &SecRequirement) -> Result<()> {
+        unsafe {
+            cvt(SecCodeCheckValidity(
+                self.as_concrete_TypeRef(),
+                flags.bits(),
+                requirement.as_concrete_TypeRef(),
+            ))
+        }
+    }
+
+    /// Asks a code host to identify one of its guests given
+    /// the type and value of specific attributes of the guest code.
+    ///
+    /// If `host` is `None` then the code signing root of trust (currently, the
+    // system kernel) should be used as the code host.
+    pub fn copy_guest_with_attribues(
+        host: Option<&SecCode>,
+        attrs: &GuestAttributes,
+        flags: Flags,
+    ) -> Result<SecCode> {
+        let mut code = MaybeUninit::uninit();
+
+        let host = match host {
+            Some(host) => host.as_concrete_TypeRef(),
+            None => std::ptr::null_mut(),
+        };
+
+        unsafe {
+            cvt(SecCodeCopyGuestWithAttributes(
+                host,
+                attrs.inner.as_concrete_TypeRef(),
+                flags.bits(),
+                code.as_mut_ptr(),
+            ))?;
+
+            Ok(SecCode::wrap_under_create_rule(code.assume_init()))
+        }
+    }
+
+    /// Retrieves the location on disk of signed code, given a code or static
+    /// code object.
+    pub fn path(&self, flags: Flags) -> Result<CFURL> {
+        let mut url = MaybeUninit::uninit();
+
+        // The docs say we can pass a SecCodeRef instead of a SecStaticCodeRef.
+        unsafe {
+            cvt(SecCodeCopyPath(
+                self.as_CFTypeRef() as _,
+                flags.bits(),
+                url.as_mut_ptr(),
+            ))?;
+
+            Ok(CFURL::wrap_under_create_rule(url.assume_init()))
+        }
+    }
+}
+
+declare_TCFType! {
+    /// A static code object representing signed code on disk.
+    SecStaticCode, SecStaticCodeRef
+}
+impl_TCFType!(SecStaticCode, SecStaticCodeRef, SecStaticCodeGetTypeID);
+
+impl SecStaticCode {
+    /// Creates a static code object representing the code at a specified file
+    /// system path.
+    pub fn from_path(path: &CFURL, flags: Flags) -> Result<Self> {
+        let mut code = MaybeUninit::uninit();
+
+        unsafe {
+            cvt(SecStaticCodeCreateWithPath(
+                path.as_concrete_TypeRef(),
+                flags.bits(),
+                code.as_mut_ptr(),
+            ))?;
+
+            Ok(Self::wrap_under_get_rule(code.assume_init()))
+        }
+    }
+
+    /// Retrieves the location on disk of signed code, given a code or static
+    /// code object.
+    pub fn path(&self, flags: Flags) -> Result<CFURL> {
+        let mut url = MaybeUninit::uninit();
+
+        // The docs say we can pass a SecCodeRef instead of a SecStaticCodeRef.
+        unsafe {
+            cvt(SecCodeCopyPath(
+                self.as_concrete_TypeRef(),
+                flags.bits(),
+                url.as_mut_ptr(),
+            ))?;
+
+            Ok(CFURL::wrap_under_create_rule(url.assume_init()))
+        }
+    }
+
+    /// Performs dynamic validation of signed code.
+    pub fn check_validity(&self, flags: Flags, requirement: &SecRequirement) -> Result<()> {
+        unsafe {
+            cvt(SecStaticCodeCheckValidity(
+                self.as_concrete_TypeRef(),
+                flags.bits(),
+                requirement.as_concrete_TypeRef(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn path_to_static_code_and_back() {
+        let path = CFURL::from_path("/bin/bash", false).unwrap();
+        let code = SecStaticCode::from_path(&path, Flags::NONE).unwrap();
+        assert_eq!(code.path(Flags::NONE).unwrap(), path);
+    }
+
+    #[test]
+    fn self_to_path() {
+        let path = CFURL::from_path(std::env::current_exe().unwrap(), false).unwrap();
+        let code = SecCode::for_self(Flags::NONE);
+        assert_eq!(code.path(Flags::NONE).unwrap(), path);
+    }
+
+    #[test]
+    fn bash_is_signed_by_apple() {
+        let path = CFURL::from_path("/bin/bash", false).unwrap();
+        let code = SecStaticCode::from_path(&path, Flags::NONE).unwrap();
+        let requirement: SecRequirement = "anchor apple".parse().unwrap();
+        code.check_validity(Flags::NONE, &requirement).unwrap();
+    }
+
+    #[test]
+    fn self_is_not_signed_by_apple() {
+        let code = SecCode::for_self(Flags::NONE);
+        let requirement: SecRequirement = "anchor apple".parse().unwrap();
+
+        assert_eq!(
+            code.check_validity(Flags::NONE, &requirement)
+                .unwrap_err()
+                .code(),
+            // "code object is not signed at all"
+            -67062
+        );
+    }
+}

--- a/security-framework/src/os/macos/mod.rs
+++ b/security-framework/src/os/macos/mod.rs
@@ -3,6 +3,7 @@
 pub mod access;
 pub mod certificate;
 pub mod certificate_oids;
+pub mod code_signing;
 pub mod digest_transform;
 pub mod encrypt_transform;
 pub mod identity;

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -19,7 +19,8 @@ fn main() {
             .header("Security/SecKeychain.h")
             .header("Security/SecKeychainItem.h")
             .header("Security/SecCertificateOIDs.h")
-            .header("Security/SecTransform.h");
+            .header("Security/SecTransform.h")
+            .header("Security/CodeSigning.h");
     }
 
     test.header("Security/SecBase.h")

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -14,6 +14,8 @@ use security_framework_sys::certificate::*;
 use security_framework_sys::certificate_oids::*;
 use security_framework_sys::cipher_suite::*;
 #[cfg(target_os = "macos")]
+use security_framework_sys::code_signing::*;
+#[cfg(target_os = "macos")]
 use security_framework_sys::digest_transform::*;
 #[cfg(target_os = "macos")]
 use security_framework_sys::encrypt_transform::*;


### PR DESCRIPTION
I'm not sure if the GuestAttributes is the right approach, maybe I'm just excessively averse to having to manually create CFDictionaries.

I'm intending to use this in another project to securely validate XPC client connections using their audit token.