### PR TITLE
Fix creating GuestAttributes

### DIFF
--- a/security-framework/src/os/macos/code_signing.rs
+++ b/security-framework/src/os/macos/code_signing.rs
@@ -124,10 +124,18 @@ impl GuestAttributes {
     // - mach port
     // - sub-architecture
 
+    /// Creates a new, empty `GuestAttributes`. You must add values to it in
+    /// order for it to be of any use.
+    pub fn new() -> Self {
+        Self {
+            inner: CFMutableDictionary::new(),
+        }
+    }
+
     /// The guest's audit token.
     pub fn set_audit_token(&mut self, token: CFDataRef) {
         let key = unsafe { CFString::wrap_under_get_rule(kSecGuestAttributeAudit) };
-        self.inner.add(&key.as_CFTypeRef(), &token.as_void_ptr());
+        self.inner.add(&key.as_CFTypeRef(), &token.to_void());
     }
 
     /// The guest's pid.


### PR DESCRIPTION
My last PR had a mistake - there's no way for users to create a GuestAttributes instance, sorry about that.

I'm just testing this now, but I wanted to open it before you published a new version. I'll update the title when I'm done later today.