### PR TITLE
Compile for Apple Silicon during CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,27 @@ jobs:
           command: check
           args: --all-features -p security-framework --target aarch64-apple-ios
 
+  apple-silicon:
+    name: Apple Silicon compile-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+
+      - name: Run check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features -p security-framework --target aarch64-apple-darwin
+
   lints:
     name: Lints
     runs-on: macos-latest


### PR DESCRIPTION
I considered combining it with the iOS job as a matrix, but I suppose the Apple Silicon target will become the main target in a few years.