### PR TITLE
Add subject, issuer, and serial_number methods

### DIFF
--- a/security-framework-sys/src/certificate.rs
+++ b/security-framework-sys/src/certificate.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 use core_foundation_sys::array::CFArrayRef;
 use core_foundation_sys::base::{CFAllocatorRef, CFTypeID, OSStatus};
 use core_foundation_sys::data::CFDataRef;
 #[cfg(target_os = "macos")]
 use core_foundation_sys::dictionary::CFDictionaryRef;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 use core_foundation_sys::error::CFErrorRef;
 use core_foundation_sys::string::CFStringRef;
 
@@ -48,11 +48,25 @@ extern "C" {
         certificate: SecCertificateRef,
         common_name: *mut CFStringRef,
     ) -> OSStatus;
+    pub fn SecCertificateCopyEmailAddresses(
+        certificate: SecCertificateRef,
+        email_addresses: *mut CFArrayRef,
+    ) -> OSStatus;
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    pub fn SecCertificateCopyNormalizedIssuerSequence(certificate: SecCertificateRef) -> CFDataRef;
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios"))]
+    pub fn SecCertificateCopyNormalizedSubjectSequence(certificate: SecCertificateRef)
+        -> CFDataRef;
     #[cfg(target_os = "macos")]
     pub fn SecCertificateCopyPublicKey(
         certificate: SecCertificateRef,
         key: *mut SecKeyRef,
     ) -> OSStatus;
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios"))]
+    pub fn SecCertificateCopySerialNumberData(
+        certificate: SecCertificateRef,
+        error: *mut CFErrorRef,
+    ) -> CFDataRef;
     #[cfg(target_os = "macos")]
     pub fn SecCertificateCopyValues(
         certificate: SecCertificateRef,

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -20,11 +20,13 @@ core-foundation-sys = "0.8.2"
 bitflags = "1.2.1"
 libc = "0.2.95"
 log = { version = "0.4.14", optional = true }
+num = "0.4.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"
 hex = "0.4.3"
 env_logger = "0.8.3"
+x509-parser = "0.10.0"
 
 [features]
 default = ["OSX_10_9"]


### PR DESCRIPTION
These methods expose the subject, issuer and serial number fields in
their DER-encoded form.

Happy to write tests, just not sure what style would fit best with the package. Would you prefer comparing against a hard coded values (byte vectors or files) or adding a test dependency on a package that can programmatically build X.509 names?