### PR TITLE
Add fingerprint method to SecCertificateExt

### DIFF
--- a/security-framework/src/os/macos/certificate.rs
+++ b/security-framework/src/os/macos/certificate.rs
@@ -3,6 +3,7 @@
 use core_foundation::array::{CFArray, CFArrayIterator};
 use core_foundation::base::TCFType;
 use core_foundation::base::ToVoid;
+use core_foundation::data::CFData;
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::error::CFError;
 use core_foundation::string::CFString;
@@ -15,6 +16,7 @@ use crate::certificate::SecCertificate;
 use crate::cvt;
 use crate::key::SecKey;
 use crate::os::macos::certificate_oids::CertificateOid;
+use crate::os::macos::digest_transform::{Builder, DigestType};
 
 /// An extension trait adding OSX specific functionality to `SecCertificate`.
 pub trait SecCertificateExt {
@@ -30,6 +32,9 @@ pub trait SecCertificateExt {
     /// subset.
     fn properties(&self, keys: Option<&[CertificateOid]>)
         -> Result<CertificateProperties, CFError>;
+
+    /// Returns the SHA-256 fingerprint of the certificate.
+    fn fingerprint(&self) -> Result<Vec<u8>, CFError>;
 }
 
 impl SecCertificateExt for SecCertificate {
@@ -82,6 +87,16 @@ impl SecCertificateExt for SecCertificate {
                 Err(CFError::wrap_under_create_rule(error))
             }
         }
+    }
+
+    /// Returns the SHA-256 fingerprint of the certificate.
+    fn fingerprint(&self) -> Result<Vec<u8>, CFError> {
+        let data = CFData::from_buffer(&self.to_der());
+        let hash = Builder::new()
+            .type_(DigestType::sha2())
+            .length(256)
+            .execute(&data)?;
+        Ok(hash.bytes().to_vec())
     }
 }
 
@@ -196,6 +211,16 @@ mod test {
     fn public_key() {
         let certificate = certificate();
         p!(certificate.public_key());
+    }
+
+    #[test]
+    fn fingerprint() {
+        let certificate = certificate();
+        let fingerprint = p!(certificate.fingerprint());
+        assert_eq!(
+            "af9dd180a326ae08b37e6398f9262f8b9d4c55674a233a7c84975024f873655d",
+            hex::encode(fingerprint)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a method for returning the SHA-256 fingerprint of a certificate on macOS. If preferable, this could be implemented in a cross-platform way by taking a dependency on CommonCrypto and calling `CC_SHA256` directly.

Verified with:
```shell
% openssl x509 -in security-framework/test/server.der -inform der -noout -fingerprint -sha256
SHA256 Fingerprint=AF:9D:D1:80:A3:26:AE:08:B3:7E:63:98:F9:26:2F:8B:9D:4C:55:67:4A:23:3A:7C:84:97:50:24:F8:73:65:5D
```