### PR TITLE
Set SSLCipherSuite width to u16 on macOS AArch64

### DIFF
--- a/security-framework-sys/src/cipher_suite.rs
+++ b/security-framework-sys/src/cipher_suite.rs
@@ -1,8 +1,11 @@
-#[cfg(not(target_os = "ios"))]
-pub type SSLCipherSuite = u32;
-
 #[cfg(target_os = "ios")]
 pub type SSLCipherSuite = u16;
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub type SSLCipherSuite = u16;
+
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
+pub type SSLCipherSuite = u32;
 
 pub const SSL_NULL_WITH_NULL_NULL: SSLCipherSuite = 0x0000;
 pub const SSL_RSA_WITH_NULL_MD5: SSLCipherSuite = 0x0001;


### PR DESCRIPTION
Fixes:
- os::macos::secure_transport::test::negotiated_cipher
- secure_transport::test::test_builder_blacklist_ciphers

on macOS AArch64.