### PR TITLE
Implement `Hash` for `SecCertificate`, `SecIdentity` and `SecKey`

### DIFF
--- a/security-framework/src/certificate.rs
+++ b/security-framework/src/certificate.rs
@@ -8,6 +8,7 @@ use core_foundation_sys::base::kCFAllocatorDefault;
 use security_framework_sys::base::{errSecParam, SecCertificateRef};
 use security_framework_sys::certificate::*;
 use std::fmt;
+use std::hash;
 use std::ptr;
 
 use crate::base::{Error, Result};
@@ -53,6 +54,12 @@ impl fmt::Debug for SecCertificate {
         fmt.debug_struct("SecCertificate")
             .field("subject", &self.subject_summary())
             .finish()
+    }
+}
+
+impl hash::Hash for SecCertificate {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.to_der().hash(state);
     }
 }
 

--- a/security-framework/src/identity.rs
+++ b/security-framework/src/identity.rs
@@ -4,6 +4,7 @@ use core_foundation::base::TCFType;
 use security_framework_sys::base::SecIdentityRef;
 use security_framework_sys::identity::*;
 use std::fmt;
+use std::hash;
 use std::ptr;
 
 use crate::base::Result;
@@ -33,6 +34,17 @@ impl fmt::Debug for SecIdentity {
             builder.field("private_key", &key);
         }
         builder.finish()
+    }
+}
+
+impl hash::Hash for SecIdentity {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        if let Ok(cert) = self.certificate() {
+            cert.hash(state);
+        }
+        if let Ok(key) = self.private_key() {
+            key.hash(state);
+        }
     }
 }
 

--- a/security-framework/src/key.rs
+++ b/security-framework/src/key.rs
@@ -18,6 +18,7 @@ use security_framework_sys::key::{
     SecKeyCopyAttributes, SecKeyCopyExternalRepresentation, SecKeyCreateSignature,
 };
 use std::fmt;
+use std::hash;
 
 declare_TCFType! {
     /// A type representing an encryption key.
@@ -80,5 +81,12 @@ impl fmt::Debug for SecKey {
     #[cold]
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "SecKey")
+    }
+}
+
+// FIXME
+impl hash::Hash for SecKey {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        "SecKey".hash(state);
     }
 }


### PR DESCRIPTION
closes #151 

I'm not quite sure how to implement this trait for `SecKey`. Any hints are greatly appreciated!