### PR TITLE
Expand Trust and Policy API bindings

### DIFF
--- a/security-framework-sys/src/base.rs
+++ b/security-framework-sys/src/base.rs
@@ -46,12 +46,16 @@ pub const errSecUnimplemented: OSStatus = -4;
 pub const errSecIO: OSStatus = -36;
 pub const errSecParam: OSStatus = -50;
 pub const errSecBadReq: OSStatus = -909;
+pub const errSecNoTrustSettings: OSStatus = -25263;
 pub const errSecAuthFailed: OSStatus = -25293;
 pub const errSecDuplicateItem: OSStatus = -25299;
+pub const errSecCreateChainFailed: OSStatus = -25318;
 pub const errSecConversionError: OSStatus = -67594;
+pub const errSecHostNameMismatch: OSStatus = -67602;
+pub const errSecInvalidExtendedKeyUsage: OSStatus = -67609;
 pub const errSecTrustSettingDeny: OSStatus = -67654;
+pub const errSecCertificateRevoked: OSStatus = -67820;
 pub const errSecNotTrusted: OSStatus = -67843;
-pub const errSecNoTrustSettings: OSStatus = -25263;
 
 extern "C" {
     // this is available on iOS 11.3+, MacOS 10.3+

--- a/security-framework-sys/src/policy.rs
+++ b/security-framework-sys/src/policy.rs
@@ -1,10 +1,29 @@
 use core_foundation_sys::base::{Boolean, CFTypeID};
+#[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+use core_foundation_sys::base::CFOptionFlags;
 use core_foundation_sys::string::CFStringRef;
 
 use crate::base::SecPolicyRef;
 
+#[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+mod revocation_flags {
+    use super::CFOptionFlags;
+
+    pub const kSecRevocationOCSPMethod: CFOptionFlags = 1 << 0;
+    pub const kSecRevocationCRLMethod: CFOptionFlags = 1 << 1;
+    pub const kSecRevocationPreferCRL: CFOptionFlags = 1 << 2;
+    pub const kSecRevocationRequirePositiveResponse: CFOptionFlags = 1 << 3;
+    pub const kSecRevocationNetworkAccessDisabled: CFOptionFlags = 1 << 4;
+    pub const kSecRevocationUseAnyAvailableMethod: CFOptionFlags = kSecRevocationOCSPMethod | kSecRevocationCRLMethod; 
+}
+
+#[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+pub use revocation_flags::*;
+
 extern "C" {
     pub fn SecPolicyCreateSSL(server: Boolean, hostname: CFStringRef) -> SecPolicyRef;
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+    pub fn SecPolicyCreateRevocation(revocationFlags: CFOptionFlags) -> SecPolicyRef;
     pub fn SecPolicyGetTypeID() -> CFTypeID;
     pub fn SecPolicyCreateBasicX509() -> SecPolicyRef;
 }

--- a/security-framework-sys/src/trust.rs
+++ b/security-framework-sys/src/trust.rs
@@ -2,6 +2,7 @@ use crate::base::SecCertificateRef;
 use crate::base::SecKeyRef;
 use core_foundation_sys::array::CFArrayRef;
 use core_foundation_sys::base::{Boolean, CFIndex, CFTypeID, CFTypeRef, OSStatus};
+use core_foundation_sys::date::CFDateRef;
 #[cfg(any(feature = "OSX_10_13", target_os = "ios"))]
 use core_foundation_sys::error::CFErrorRef;
 
@@ -15,6 +16,23 @@ pub const kSecTrustResultRecoverableTrustFailure: SecTrustResultType = 5;
 pub const kSecTrustResultFatalTrustFailure: SecTrustResultType = 6;
 pub const kSecTrustResultOtherError: SecTrustResultType = 7;
 
+
+#[cfg(target_os = "macos")]
+mod flags {
+    pub type SecTrustOptionFlags = u32;
+
+    pub const kSecTrustOptionAllowExpired: SecTrustOptionFlags = 0x00000001;
+    pub const kSecTrustOptionLeafIsCA: SecTrustOptionFlags = 0x00000002;
+    pub const kSecTrustOptionFetchIssuerFromNet: SecTrustOptionFlags = 0x00000004;
+    pub const kSecTrustOptionAllowExpiredRoot: SecTrustOptionFlags = 0x00000008;
+    pub const kSecTrustOptionRequireRevPerCert: SecTrustOptionFlags= 0x00000010;
+    pub const kSecTrustOptionUseTrustSettings: SecTrustOptionFlags= 0x00000020;
+    pub const kSecTrustOptionImplicitAnchors: SecTrustOptionFlags= 0x00000040;
+}
+
+#[cfg(target_os = "macos")]
+pub use flags::*;
+
 pub enum __SecTrust {}
 
 pub type SecTrustRef = *mut __SecTrust;
@@ -24,6 +42,7 @@ extern "C" {
     pub fn SecTrustGetCertificateCount(trust: SecTrustRef) -> CFIndex;
     #[deprecated(note = "deprecated by Apple")]
     pub fn SecTrustGetCertificateAtIndex(trust: SecTrustRef, ix: CFIndex) -> SecCertificateRef;
+    pub fn SecTrustSetVerifyDate(trust: SecTrustRef, verifyDate: CFDateRef) -> OSStatus;
     pub fn SecTrustSetAnchorCertificates(
         trust: SecTrustRef,
         anchorCertificates: CFArrayRef,
@@ -45,5 +64,15 @@ extern "C" {
         trust: *mut SecTrustRef,
     ) -> OSStatus;
     pub fn SecTrustSetPolicies(trust: SecTrustRef, policies: CFTypeRef) -> OSStatus;
+    #[cfg(target_os = "macos")]
+    pub fn SecTrustSetOptions(trust: SecTrustRef, options: SecTrustOptionFlags) -> OSStatus;
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+    pub fn SecTrustGetNetworkFetchAllowed(trust: SecTrustRef, allowFetch: *mut Boolean) -> OSStatus;
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+    pub fn SecTrustSetNetworkFetchAllowed(trust: SecTrustRef, allowFetch: Boolean) -> OSStatus;
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios"))]
+    pub fn SecTrustSetOCSPResponse(trust: SecTrustRef, responseData: CFTypeRef) -> OSStatus;
+    #[cfg(any(feature = "OSX_10_14", target_os = "ios"))]
+    pub fn SecTrustSetSignedCertificateTimestamps(trust: SecTrustRef, sctArray: CFArrayRef) -> OSStatus;
     pub fn SecTrustCopyPublicKey(trust: SecTrustRef) -> SecKeyRef;
 }

--- a/systest/src/main.rs
+++ b/systest/src/main.rs
@@ -4,7 +4,7 @@
 #![allow(deref_nullptr)]
 #![allow(invalid_value)] // mem::uninitialized has to stay
 
-use core_foundation_sys::base::OSStatus;
+use core_foundation_sys::base::{OSStatus, CFOptionFlags};
 use core_foundation_sys::string::CFStringRef;
 use std::os::raw::*;
 


### PR DESCRIPTION
This PR adds bindings to both `security-framework-sys` and `security-framework` for most* of the rest of the `SecTrust` related and policy creation APIs.

The only thing I'm not sure about is the correct way to expose methods like `SecTrustSetSignedCertificateTimestamps` and `SecTrustSetOCSPResponse`, which accept arrays of arbitrary data blobs, in `security-framework`'s public API. Other methods like this have corresponding `core-foundation` types, like `SecCertificate`. Given this, for now I've opted to expose `CFData` in the public API methods to allow the caller to control all allocation. Otherwise, I believe the methods would need to take an iterator and allocate a `Vec<CFData>` internally to work correctly.

Thanks!