### PR TITLE
SMJobBless

### DIFF
--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = "1.3.2"
 libc = "0.2.100"
 log = { version = "0.4.14", optional = true }
 num-bigint = { version = "0.4.3", optional = true }
+service-management-sys = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -34,6 +35,7 @@ alpn = []
 session-tickets = []
 # deprecated, do not use
 serial-number-bigint = ["num-bigint"]
+job-bless = ["service-management-sys"]
 
 OSX_10_9 = ["security-framework-sys/OSX_10_9"]
 OSX_10_10 = ["OSX_10_9", "security-framework-sys/OSX_10_10"]

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -552,13 +552,13 @@ impl<'a> Authorization {
 
     /// Submits the executable for the given label as a `launchd` job.
     #[cfg(all(target_os = "macos", feature = "job-bless"))]
-    pub fn job_bless(&self, domain: CFStringRef, label: &str) -> Result<(), CFError> {
-        use service_management_sys::service_management::SMJobBless;
+    pub fn job_bless(&self, label: &str) -> Result<(), CFError> {
+        use service_management_sys::service_management::{kSMDomainSystemLaunchd, SMJobBless};
 
         unsafe {
             let mut error = std::ptr::null_mut();
             SMJobBless(
-                domain,
+                kSMDomainSystemLaunchd,
                 CFString::new(label).as_concrete_TypeRef(),
                 self.handle,
                 &mut error

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -552,13 +552,13 @@ impl<'a> Authorization {
 
     /// Submits the executable for the given label as a `launchd` job.
     #[cfg(all(target_os = "macos", feature = "job-bless"))]
-    pub fn job_bless(&self, domain: Option<&str>, label: Option<&str>) -> Result<(), CFError> {
+    pub fn job_bless(&self, domain: CFStringRef, label: Option<&str>) -> Result<(), CFError> {
         use service_management_sys::service_management::SMJobBless;
 
         unsafe {
             let mut error = std::ptr::null_mut();
             SMJobBless(
-                optional_str_to_cfref!(domain),
+                domain,
                 optional_str_to_cfref!(label),
                 self.handle,
                 &mut error

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -11,6 +11,8 @@ use core_foundation::base::{CFTypeRef, TCFType};
 use core_foundation::bundle::CFBundleRef;
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::{CFString, CFStringRef};
+#[cfg(all(target_os = "macos", feature = "job-bless"))]
+use core_foundation::error::CFError;
 use security_framework_sys::authorization as sys;
 use security_framework_sys::base::errSecConversionError;
 use std::mem::MaybeUninit;
@@ -546,6 +548,27 @@ impl<'a> Authorization {
             .into_iter().flat_map(|a| CString::new(a.as_ref().as_bytes()))
             .collect::<Vec<_>>();
         Ok(self.execute_with_privileges_internal(command.as_ref().as_os_str().as_bytes(), &arguments, flags, true)?.unwrap())
+    }
+
+    /// Submits the executable for the given label as a `launchd` job.
+    #[cfg(all(target_os = "macos", feature = "job-bless"))]
+    pub fn job_bless(&self, domain: Option<&str>, label: Option<&str>) -> Result<(), CFError> {
+        use service_management_sys::service_management::SMJobBless;
+
+        unsafe {
+            let mut error = std::ptr::null_mut();
+            SMJobBless(
+                optional_str_to_cfref!(domain),
+                optional_str_to_cfref!(label),
+                self.handle,
+                &mut error
+            );
+            if !error.is_null() {
+                return Err(CFError::wrap_under_create_rule(error));
+            }
+
+            Ok(())
+        }
     }
 
     // Runs an executable tool with root privileges.

--- a/security-framework/src/authorization.rs
+++ b/security-framework/src/authorization.rs
@@ -552,14 +552,14 @@ impl<'a> Authorization {
 
     /// Submits the executable for the given label as a `launchd` job.
     #[cfg(all(target_os = "macos", feature = "job-bless"))]
-    pub fn job_bless(&self, domain: CFStringRef, label: Option<&str>) -> Result<(), CFError> {
+    pub fn job_bless(&self, domain: CFStringRef, label: &str) -> Result<(), CFError> {
         use service_management_sys::service_management::SMJobBless;
 
         unsafe {
             let mut error = std::ptr::null_mut();
             SMJobBless(
                 domain,
-                optional_str_to_cfref!(label),
+                CFString::new(label).as_concrete_TypeRef(),
                 self.handle,
                 &mut error
             );


### PR DESCRIPTION
Since we cannot do `as_concrete_TypeRef()` on `Authorization`, I guess implementing `SMJobBless` directly within it would be okay.