### PR TITLE
Support calling with the default keychain

### DIFF
--- a/security-framework/src/os/macos/identity.rs
+++ b/security-framework/src/os/macos/identity.rs
@@ -14,6 +14,10 @@ use crate::os::macos::keychain::SecKeychain;
 pub trait SecIdentityExt {
     /// Creates an identity corresponding to a certificate, looking in the
     /// provided keychains for the corresponding private key.
+    /// 
+    /// To search the default keychains, use an empty slice for `keychains`.
+    /// 
+    /// <https://developer.apple.com/documentation/security/1401160-secidentitycreatewithcertificate>
     fn with_certificate(
         keychains: &[SecKeychain],
         certificate: &SecCertificate,
@@ -29,7 +33,7 @@ impl SecIdentityExt for SecIdentity {
         unsafe {
             let mut identity = ptr::null_mut();
             cvt(SecIdentityCreateWithCertificate(
-                keychains.as_CFTypeRef(),
+                if keychains.len() > 0 {keychains.as_CFTypeRef()} else {ptr::null()},
                 certificate.as_concrete_TypeRef(),
                 &mut identity,
             ))?;


### PR DESCRIPTION
SecIdentityCreateWithCertificate accepts NULL as the first parameter to search the default keychain.

https://developer.apple.com/documentation/security/1401160-secidentitycreatewithcertificate https://developer.apple.com/documentation/security/certificate_key_and_trust_services/identities/creating_an_identity