### PR TITLE
Fix memory leak in SecStaticCode::from_path()

### DIFF
--- a/security-framework/src/os/macos/code_signing.rs
+++ b/security-framework/src/os/macos/code_signing.rs
@@ -283,7 +283,7 @@ impl SecStaticCode {
                 code.as_mut_ptr(),
             ))?;
 
-            Ok(Self::wrap_under_get_rule(code.assume_init()))
+            Ok(Self::wrap_under_create_rule(code.assume_init()))
         }
     }
 


### PR DESCRIPTION
`SecStaticCode::from_path()` calls `SecStaticCodeCreateWithPath`, which follows the Create Rule, so it should be wrapped using `wrap_under_create_rule` and not `wrap_under_get_rule`.