### PR TITLE
security-framework::item::ItemSearchOptions: support trusted_only

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -11,6 +11,8 @@ extern "C" {
     pub static kSecMatchLimit: CFStringRef;
     pub static kSecMatchLimitAll: CFStringRef;
 
+    pub static kSecMatchTrustedOnly: CFStringRef;
+
     pub static kSecReturnData: CFStringRef;
     pub static kSecReturnAttributes: CFStringRef;
     pub static kSecReturnRef: CFStringRef;

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -327,7 +327,7 @@ impl ItemSearchOptions {
             if let Some(ref trusted_only) = self.trusted_only {
                 params.push((
                     CFString::wrap_under_get_rule(kSecMatchTrustedOnly),
-                    if *trusted_only { CFBoolean::true_value().into_CFType() } else { CFBoolean::true_value().into_CFType() },
+                    if *trusted_only { CFBoolean::true_value().into_CFType() } else { CFBoolean::false_value().into_CFType() },
                 ));
             }
 

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -137,6 +137,7 @@ pub struct ItemSearchOptions {
     load_attributes: bool,
     load_data: bool,
     limit: Option<Limit>,
+    trusted_only: Option<bool>,
     label: Option<CFString>,
     service: Option<CFString>,
     account: Option<CFString>,
@@ -215,6 +216,13 @@ impl ItemSearchOptions {
     #[inline(always)]
     pub fn label(&mut self, label: &str) -> &mut Self {
         self.label = Some(CFString::new(label));
+        self
+    }
+
+    /// Whether untrusted certificates should be returned.
+    #[inline(always)]
+    pub fn trusted_only(&mut self, trusted_only: Option<bool>) -> &mut Self {
+        self.trusted_only = trusted_only;
         self
     }
 
@@ -313,6 +321,13 @@ impl ItemSearchOptions {
                 params.push((
                     CFString::wrap_under_get_rule(kSecAttrLabel),
                     label.as_CFType(),
+                ));
+            }
+
+            if let Some(ref trusted_only) = self.trusted_only {
+                params.push((
+                    CFString::wrap_under_get_rule(kSecMatchTrustedOnly),
+                    if *trusted_only { CFBoolean::true_value().into_CFType() } else { CFBoolean::true_value().into_CFType() },
                 ));
             }
 


### PR DESCRIPTION
Extends the search options interface to support the kSecMatchTrustedOnly query option.