### PR TITLE
Added visionos support

### DIFF
--- a/security-framework-sys/src/certificate.rs
+++ b/security-framework-sys/src/certificate.rs
@@ -3,7 +3,7 @@ use core_foundation_sys::base::{CFAllocatorRef, CFTypeID, OSStatus};
 use core_foundation_sys::data::CFDataRef;
 #[cfg(target_os = "macos")]
 use core_foundation_sys::dictionary::CFDictionaryRef;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation_sys::error::CFErrorRef;
 use core_foundation_sys::string::CFStringRef;
 
@@ -55,9 +55,9 @@ extern "C" {
         certificate: SecCertificateRef,
         email_addresses: *mut CFArrayRef,
     ) -> OSStatus;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecCertificateCopyNormalizedIssuerSequence(certificate: SecCertificateRef) -> CFDataRef;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecCertificateCopyNormalizedSubjectSequence(certificate: SecCertificateRef)
         -> CFDataRef;
     #[cfg(target_os = "macos")]
@@ -67,9 +67,9 @@ extern "C" {
         certificate: SecCertificateRef,
         key: *mut SecKeyRef,
     ) -> OSStatus;
-    #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecCertificateCopyKey(certificate: SecCertificateRef) -> SecKeyRef;
-    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecCertificateCopySerialNumberData(
         certificate: SecCertificateRef,
         error: *mut CFErrorRef,

--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -34,11 +34,11 @@ extern "C" {
     pub static kSecAttrKeyClassSymmetric: CFStringRef;
 
     pub static kSecUseKeychain: CFStringRef;
-    #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecUseDataProtectionKeychain: CFStringRef;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecAttrTokenID: CFStringRef;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecAttrTokenIDSecureEnclave: CFStringRef;
 
     pub static kSecAttrKeySizeInBits: CFStringRef;
@@ -59,7 +59,7 @@ extern "C" {
     pub static kSecAttrKeyTypeRC2: CFStringRef;
     #[cfg(target_os = "macos")]
     pub static kSecAttrKeyTypeCAST: CFStringRef;
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecAttrKeyTypeEC: CFStringRef;
 
     pub static kSecAttrAccessGroup: CFStringRef;

--- a/security-framework-sys/src/key.rs
+++ b/security-framework-sys/src/key.rs
@@ -2,31 +2,31 @@ use core_foundation_sys::base::CFTypeID;
 use core_foundation_sys::data::CFDataRef;
 use core_foundation_sys::dictionary::CFDictionaryRef;
 use core_foundation_sys::error::CFErrorRef;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation_sys::string::CFStringRef;
 
 use crate::base::SecKeyRef;
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub type SecKeyAlgorithm = CFStringRef;
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub type SecKeyOperationType = u32;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSecKeyOperationTypeSign: SecKeyOperationType = 0;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSecKeyOperationTypeVerify: SecKeyOperationType = 1;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSecKeyOperationTypeEncrypt: SecKeyOperationType = 2;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSecKeyOperationTypeDecrypt: SecKeyOperationType = 3;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSecKeyOperationTypeKeyExchange: SecKeyOperationType = 4;
 
 extern "C" {
     pub fn SecKeyGetTypeID() -> CFTypeID;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyCreateRandomKey(parameters: CFDictionaryRef, error: *mut CFErrorRef) -> SecKeyRef;
 
     #[cfg(target_os = "macos")]
@@ -36,14 +36,14 @@ extern "C" {
         error: *mut CFErrorRef,
     ) -> SecKeyRef;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyCopyExternalRepresentation(key: SecKeyRef, error: *mut CFErrorRef) -> CFDataRef;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyCopyAttributes(key: SecKeyRef) -> CFDictionaryRef;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyCopyPublicKey(key: SecKeyRef) -> SecKeyRef;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyCreateSignature(
         key: SecKeyRef,
         algorithm: SecKeyAlgorithm,
@@ -51,7 +51,7 @@ extern "C" {
         error: *mut CFErrorRef,
     ) -> CFDataRef;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyVerifySignature(
         key: SecKeyRef,
         algorithm: SecKeyAlgorithm,
@@ -60,7 +60,7 @@ extern "C" {
         error: *mut CFErrorRef,
     ) -> core_foundation_sys::base::Boolean;
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyIsAlgorithmSupported(
         key: SecKeyRef,
         operation: SecKeyOperationType,
@@ -68,7 +68,7 @@ extern "C" {
     ) -> core_foundation_sys::base::Boolean;
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 macro_rules! names {
     ($($i:ident => $x:ident),*) => {
         extern "C" {
@@ -91,7 +91,7 @@ macro_rules! names {
     }
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 names! {
     ECIESEncryptionStandardX963SHA1AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA1AESGCM,
     ECIESEncryptionStandardX963SHA224AESGCM => kSecKeyAlgorithmECIESEncryptionStandardX963SHA224AESGCM,

--- a/security-framework-sys/src/lib.rs
+++ b/security-framework-sys/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(bad_style)]
 
 #[cfg_attr(
-    any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"),
+    any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"),
     link(name = "Security", kind = "framework")
 )]
 extern "C" {}
@@ -12,7 +12,7 @@ pub mod access_control;
 #[cfg(target_os = "macos")]
 pub mod authorization;
 pub mod base;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod certificate;
 #[cfg(target_os = "macos")]
 pub mod certificate_oids;

--- a/security-framework-sys/src/policy.rs
+++ b/security-framework-sys/src/policy.rs
@@ -1,11 +1,11 @@
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation_sys::base::CFOptionFlags;
 use core_foundation_sys::base::{Boolean, CFTypeID};
 use core_foundation_sys::string::CFStringRef;
 
 use crate::base::SecPolicyRef;
 
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 mod revocation_flags {
     use super::CFOptionFlags;
 
@@ -17,12 +17,12 @@ mod revocation_flags {
     pub const kSecRevocationUseAnyAvailableMethod: CFOptionFlags = kSecRevocationOCSPMethod | kSecRevocationCRLMethod;
 }
 
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub use revocation_flags::*;
 
 extern "C" {
     pub fn SecPolicyCreateSSL(server: Boolean, hostname: CFStringRef) -> SecPolicyRef;
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecPolicyCreateRevocation(revocationFlags: CFOptionFlags) -> SecPolicyRef;
     pub fn SecPolicyGetTypeID() -> CFTypeID;
     pub fn SecPolicyCreateBasicX509() -> SecPolicyRef;

--- a/security-framework-sys/src/secure_transport.rs
+++ b/security-framework-sys/src/secure_transport.rs
@@ -30,15 +30,15 @@ pub type SSLSessionOption = c_int;
 pub const kSSLSessionOptionBreakOnServerAuth: SSLSessionOption = 0;
 pub const kSSLSessionOptionBreakOnCertRequested: SSLSessionOption = 1;
 pub const kSSLSessionOptionBreakOnClientAuth: SSLSessionOption = 2;
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSSLSessionOptionFalseStart: SSLSessionOption = 3;
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub const kSSLSessionOptionSendOneByteRecord: SSLSessionOption = 4;
-#[cfg(all(feature = "OSX_10_11", not(any(target_os = "ios", target_os = "tvos", target_os = "watchos"))))]
+#[cfg(all(feature = "OSX_10_11", not(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))))]
 pub const kSSLSessionOptionAllowServerIdentityChange: SSLSessionOption = 5;
-#[cfg(all(feature = "OSX_10_10", not(any(target_os = "ios", target_os = "tvos", target_os = "watchos"))))]
+#[cfg(all(feature = "OSX_10_10", not(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))))]
 pub const kSSLSessionOptionFallback: SSLSessionOption = 6;
-#[cfg(all(feature = "OSX_10_11", not(any(target_os = "ios", target_os = "tvos", target_os = "watchos"))))]
+#[cfg(all(feature = "OSX_10_11", not(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))))]
 pub const kSSLSessionOptionBreakOnClientHello: SSLSessionOption = 7;
 
 pub type SSLSessionState = c_int;

--- a/security-framework-sys/src/trust.rs
+++ b/security-framework-sys/src/trust.rs
@@ -3,7 +3,7 @@ use crate::base::SecKeyRef;
 use core_foundation_sys::array::CFArrayRef;
 use core_foundation_sys::base::{Boolean, CFIndex, CFTypeID, CFTypeRef, OSStatus};
 use core_foundation_sys::date::CFDateRef;
-#[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation_sys::error::CFErrorRef;
 
 pub type SecTrustResultType = u32;
@@ -55,7 +55,7 @@ extern "C" {
     #[deprecated(note = "deprecated by Apple")]
     pub fn SecTrustEvaluate(trust: SecTrustRef, result: *mut SecTrustResultType) -> OSStatus;
     // it should have been OSX_10_14, but due to back-compat it can't rely on the newer feature flag
-    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecTrustEvaluateWithError(trust: SecTrustRef, error: *mut CFErrorRef) -> bool;
     pub fn SecTrustCreateWithCertificates(
         certificates: CFTypeRef,
@@ -65,13 +65,13 @@ extern "C" {
     pub fn SecTrustSetPolicies(trust: SecTrustRef, policies: CFTypeRef) -> OSStatus;
     #[cfg(target_os = "macos")]
     pub fn SecTrustSetOptions(trust: SecTrustRef, options: SecTrustOptionFlags) -> OSStatus;
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecTrustGetNetworkFetchAllowed(trust: SecTrustRef, allowFetch: *mut Boolean) -> OSStatus;
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecTrustSetNetworkFetchAllowed(trust: SecTrustRef, allowFetch: Boolean) -> OSStatus;
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecTrustSetOCSPResponse(trust: SecTrustRef, responseData: CFTypeRef) -> OSStatus;
-    #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecTrustSetSignedCertificateTimestamps(
         trust: SecTrustRef,
         sctArray: CFArrayRef,

--- a/security-framework/src/certificate.rs
+++ b/security-framework/src/certificate.rs
@@ -6,7 +6,7 @@ use core_foundation::data::CFData;
 use core_foundation::dictionary::CFMutableDictionary;
 use core_foundation::string::CFString;
 use core_foundation_sys::base::kCFAllocatorDefault;
-#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use security_framework_sys::base::{errSecNotTrusted, errSecSuccess};
 use security_framework_sys::base::{errSecParam, SecCertificateRef};
 use security_framework_sys::certificate::*;
@@ -16,20 +16,20 @@ use std::ptr;
 
 use crate::base::{Error, Result};
 use crate::cvt;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use crate::key;
 #[cfg(target_os = "macos")]
 use crate::os::macos::keychain::SecKeychain;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::base::FromVoid;
-#[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::error::{CFError, CFErrorRef};
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::number::CFNumber;
 #[cfg(feature = "serial-number-bigint")]
 use num_bigint::BigUint;
 use security_framework_sys::item::kSecValueRef;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use std::ops::Deref;
 
 declare_TCFType! {
@@ -109,7 +109,7 @@ impl SecCertificate {
         }
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Returns DER encoded X.509 distinguished name of the certificate issuer.
     #[must_use]
     pub fn issuer(&self) -> Vec<u8> {
@@ -119,7 +119,7 @@ impl SecCertificate {
         }
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Returns DER encoded X.509 distinguished name of the certificate subject.
     #[must_use]
     pub fn subject(&self) -> Vec<u8> {
@@ -129,7 +129,7 @@ impl SecCertificate {
         }
     }
 
-    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Returns DER encoded serial number of the certificate.
     pub fn serial_number_bytes(&self) -> Result<Vec<u8>, CFError> {
         unsafe {
@@ -150,7 +150,7 @@ impl SecCertificate {
         Ok(BigUint::from_bytes_be(&self.serial_number_bytes()?))
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Returns DER encoded subjectPublicKeyInfo of certificate if available. This can be used
     /// for certificate pinning.
     pub fn public_key_info_der(&self) -> Result<Option<Vec<u8>>> {
@@ -160,7 +160,7 @@ impl SecCertificate {
         Ok(self.pk_to_der(public_key))
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     #[must_use]
     fn pk_to_der(&self, public_key: key::SecKey) -> Option<Vec<u8>> {
         use security_framework_sys::item::kSecAttrKeyType;
@@ -184,7 +184,7 @@ impl SecCertificate {
         Some(out)
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Get public key from certificate
     pub fn public_key(&self) -> Result<key::SecKey> {
         use crate::policy::SecPolicy;
@@ -194,9 +194,9 @@ impl SecCertificate {
         let policy = SecPolicy::create_x509();
         let mut trust = SecTrust::create_with_certificates(from_ref(self), from_ref(&policy))?;
         #[allow(deprecated)]
-        #[cfg(not(any(target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+        #[cfg(not(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos")))]
         trust.evaluate()?;
-        #[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+        #[cfg(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
         cvt(match trust.evaluate_with_error() {
             Ok(_) => errSecSuccess,
             Err(_) => errSecNotTrusted,
@@ -215,7 +215,7 @@ impl SecCertificate {
     }
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 fn get_asn1_header_bytes(pkt: CFString, ksz: u32) -> Option<&'static [u8]> {
     use security_framework_sys::item::kSecAttrKeyTypeRSA;
     use security_framework_sys::item::kSecAttrKeyTypeECSECPrimeRandom;
@@ -239,25 +239,25 @@ fn get_asn1_header_bytes(pkt: CFString, ksz: u32) -> Option<&'static [u8]> {
     None
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 const RSA_2048_ASN1_HEADER: [u8; 24] = [
     0x30, 0x82, 0x01, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
     0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0f, 0x00,
 ];
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 const RSA_4096_ASN1_HEADER: [u8; 24] = [
     0x30, 0x82, 0x02, 0x22, 0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
     0x01, 0x05, 0x00, 0x03, 0x82, 0x02, 0x0f, 0x00,
 ];
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 const EC_DSA_SECP_256_R1_ASN1_HEADER: [u8; 26] = [
     0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a,
     0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
 ];
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 const EC_DSA_SECP_384_R1_ASN1_HEADER: [u8; 23] = [
     0x30, 0x76, 0x30, 0x10, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x05, 0x2b,
     0x81, 0x04, 0x00, 0x22, 0x03, 0x62, 0x00,
@@ -268,7 +268,7 @@ mod test {
     use crate::test::certificate;
     #[cfg(feature = "serial-number-bigint")]
     use num_bigint::BigUint;
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     use x509_parser::prelude::*;
 
     #[test]
@@ -284,7 +284,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     fn issuer() {
         let cert = certificate();
         let issuer = cert.issuer();
@@ -297,7 +297,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     fn subject() {
         let cert = certificate();
         let subject = cert.subject();

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -620,7 +620,7 @@ impl ItemAddOptions {
 
         if let Some(location) = &self.location {
             match location {
-                #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+                #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
                 Location::DataProtectionKeychain => {
                     dict.add(
                         &unsafe { kSecUseDataProtectionKeychain }.to_void(),
@@ -712,7 +712,7 @@ pub enum Location {
     /// This keychain requires the calling binary to be codesigned with
     /// entitlements for the KeychainAccessGroups it is supposed to
     /// access.
-    #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     DataProtectionKeychain,
     /// Store the key in the default file-based keychain. On macOS, defaults to
     /// the Login keychain.

--- a/security-framework/src/key.rs
+++ b/security-framework/src/key.rs
@@ -6,22 +6,22 @@ use core_foundation::{
     dictionary::CFMutableDictionary,
 };
 use core_foundation::base::ToVoid;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::boolean::CFBoolean;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::data::CFData;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::dictionary::CFDictionary;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::number::CFNumber;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::error::{CFError, CFErrorRef};
 
 use security_framework_sys::{
     item::{kSecAttrKeyTypeRSA, kSecValueRef},
     keychain_item::SecItemDelete
 };
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use security_framework_sys::{item::{
     kSecAttrIsPermanent, kSecAttrLabel, kSecAttrKeyType,
     kSecAttrKeySizeInBits, kSecPrivateKeyAttrs, kSecAttrAccessControl
@@ -35,24 +35,24 @@ use security_framework_sys::item::{
 use security_framework_sys::key::SecKeyGetTypeID;
 use security_framework_sys::base::SecKeyRef;
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub use security_framework_sys::key::Algorithm;
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use security_framework_sys::key::{
     SecKeyCopyAttributes, SecKeyCopyExternalRepresentation,
     SecKeyCreateSignature, SecKeyCreateRandomKey,
     SecKeyCopyPublicKey,
 };
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use security_framework_sys::item::kSecAttrApplicationLabel;
 use std::fmt;
 
 
 use crate::base::Error;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use crate::item::Location;
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use crate::access_control::SecAccessControl;
 /// Types of `SecKey`s.
 #[derive(Debug, Copy, Clone)]
@@ -108,7 +108,7 @@ impl KeyType {
         unsafe { Self(kSecAttrKeyTypeCAST) }
     }
 
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     #[inline(always)]
     #[must_use]
     pub fn ec() -> Self {
@@ -132,7 +132,7 @@ unsafe impl Sync for SecKey {}
 unsafe impl Send for SecKey {}
 
 impl SecKey {
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Translates to `SecKeyCreateRandomKey`
     /// `GenerateKeyOptions` provides a helper to create an attribute
     /// `CFDictionary`.
@@ -149,14 +149,14 @@ impl SecKey {
     /// Returns the programmatic identifier for the key. For keys of class
     /// kSecAttrKeyClassPublic and kSecAttrKeyClassPrivate, the value is the
     /// hash of the public key.
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn application_label(&self) -> Option<Vec<u8>> {
         self.attributes()
             .find(unsafe { kSecAttrApplicationLabel.to_void() })
             .map(|v| unsafe { CFData::wrap_under_get_rule(v.cast()) }.to_vec())
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Translates to `SecKeyCopyAttributes`
     #[must_use]
     pub fn attributes(&self) -> CFDictionary {
@@ -164,7 +164,7 @@ impl SecKey {
         unsafe { CFDictionary::wrap_under_create_rule(pka) }
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Translates to `SecKeyCopyExternalRepresentation`
     #[must_use]
     pub fn external_representation(&self) -> Option<CFData> {
@@ -176,7 +176,7 @@ impl SecKey {
         Some(unsafe { CFData::wrap_under_create_rule(data) })
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Translates to `SecKeyCopyPublicKey`
     #[must_use]
     pub fn public_key(&self) -> Option<Self> {
@@ -188,7 +188,7 @@ impl SecKey {
         Some(unsafe { SecKey::wrap_under_create_rule(pub_seckey) })
     }
 
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Creates the cryptographic signature for a block of data using a private
     /// key and specified algorithm.
     pub fn create_signature(&self, algorithm: Algorithm, input: &[u8]) -> Result<Vec<u8>, CFError> {
@@ -213,7 +213,7 @@ impl SecKey {
 
     /// Verifies the cryptographic signature for a block of data using a public
     /// key and specified algorithm.
-    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn verify_signature(&self, algorithm: Algorithm, signed_data: &[u8], signature: &[u8]) -> Result<bool, CFError> {
         use security_framework_sys::key::SecKeyVerifySignature;
         let mut error: CFErrorRef = std::ptr::null_mut();
@@ -258,7 +258,7 @@ pub enum Token {
 /// Recommended reading:
 /// <https://developer.apple.com/documentation/technotes/tn3137-on-mac-keychains>
 #[derive(Default)]
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub struct GenerateKeyOptions {
     /// kSecAttrKeyType
     pub key_type: Option<KeyType>,
@@ -274,7 +274,7 @@ pub struct GenerateKeyOptions {
     pub access_control: Option<SecAccessControl>,
 }
 
-#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 impl GenerateKeyOptions {
     /// Set `key_type`
     pub fn set_key_type(&mut self, key_type: KeyType) -> &mut Self {

--- a/security-framework/src/lib.rs
+++ b/security-framework/src/lib.rs
@@ -34,26 +34,26 @@ pub mod access_control;
 #[cfg(target_os = "macos")]
 pub mod authorization;
 pub mod base;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod certificate;
 pub mod cipher_suite;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod identity;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod import_export;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod item;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod key;
 pub mod os;
 pub mod passwords;
 pub mod passwords_options;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod policy;
 pub mod random;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod secure_transport;
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 pub mod trust;
 #[cfg(target_os = "macos")]
 pub mod trust_settings;

--- a/security-framework/src/policy.rs
+++ b/security-framework/src/policy.rs
@@ -1,9 +1,9 @@
 //! Security Policies support.
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::base::CFOptionFlags;
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use security_framework_sys::base::errSecParam;
 use security_framework_sys::base::SecPolicyRef;
 use security_framework_sys::policy::*;
@@ -11,7 +11,7 @@ use std::fmt;
 use std::ptr;
 
 use crate::secure_transport::SslProtocolSide;
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use crate::Error;
 
 declare_TCFType! {
@@ -30,7 +30,7 @@ impl fmt::Debug for SecPolicy {
     }
 }
 
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 bitflags::bitflags! {
     /// The flags used to specify revocation policy options.
     pub struct RevocationPolicy: CFOptionFlags {
@@ -67,7 +67,7 @@ impl SecPolicy {
         }
     }
 
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     /// Creates a `SecPolicy` for checking revocation of certificates.
     ///
     /// If you do not specify this policy creating a `SecTrust` object, the system defaults

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -1685,7 +1685,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(any(target_os = "ios", target_os = "tvos", target_os = "watchos"), ignore)] // FIXME what's going on with ios?
+    #[cfg_attr(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"), ignore)] // FIXME what's going on with ios?
     fn cipher_configuration() {
         let mut ctx = p!(SslContext::new(
             SslProtocolSide::SERVER,
@@ -1721,7 +1721,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(any(target_os = "ios", target_os = "tvos", target_os = "watchos"), ignore)] // FIXME same issue as cipher_configuration
+    #[cfg_attr(any(target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"), ignore)] // FIXME same issue as cipher_configuration
     fn test_builder_blacklist_ciphers() {
         let stream = p!(TcpStream::connect("google.com:443"));
 

--- a/security-framework/src/trust.rs
+++ b/security-framework/src/trust.rs
@@ -4,7 +4,7 @@ use core_foundation::array::CFArray;
 #[cfg(target_os = "macos")]
 use core_foundation::array::CFArrayRef;
 use core_foundation::base::TCFType;
-#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
 use core_foundation::data::CFData;
 use core_foundation::date::CFDate;
 use core_foundation_sys::base::{Boolean, CFIndex};
@@ -164,7 +164,7 @@ impl SecTrust {
 
     /// Indicates whether this trust object is permitted to
     /// fetch missing intermediate certificates from the network.
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn get_network_fetch_allowed(&mut self) -> Result<bool> {
         let mut allowed = 0;
 
@@ -175,7 +175,7 @@ impl SecTrust {
 
     /// Specifies whether this trust object is permitted to
     /// fetch missing intermediate certificates from the network.
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     #[inline]
     pub fn set_network_fetch_allowed(&mut self, allowed: bool) -> Result<()> {
         unsafe { cvt(SecTrustSetNetworkFetchAllowed(self.0, allowed as u8)) }
@@ -183,7 +183,7 @@ impl SecTrust {
 
     /// Attaches Online Certificate Status Protocol (OSCP) response data
     /// to this trust object.
-    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_9", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn set_trust_ocsp_response<I: Iterator<Item = impl AsRef<[u8]>>>(
         &mut self,
         ocsp_response: I,
@@ -199,7 +199,7 @@ impl SecTrust {
     }
 
     /// Attaches signed certificate timestamp data to this trust object.
-    #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn set_signed_certificate_timestamps<I: Iterator<Item = impl AsRef<[u8]>>>(
         &mut self,
         scts: I,
@@ -237,7 +237,7 @@ impl SecTrust {
 
     /// Evaluates trust. Requires macOS 10.14 or iOS, otherwise it just calls `evaluate()`
     pub fn evaluate_with_error(&self) -> Result<(), CFError> {
-        #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+        #[cfg(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
         unsafe {
             let mut error: CFErrorRef = ::std::ptr::null_mut();
             if !SecTrustEvaluateWithError(self.0, &mut error) {
@@ -247,7 +247,7 @@ impl SecTrust {
             }
             Ok(())
         }
-        #[cfg(not(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+        #[cfg(not(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos")))]
         #[allow(deprecated)]
         {
             use security_framework_sys::base::errSecNotTrusted;
@@ -290,12 +290,12 @@ impl SecTrust {
     }
 }
 
-#[cfg(not(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+#[cfg(not(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos")))]
 extern "C" {
     fn CFErrorCreate(allocator: core_foundation_sys::base::CFAllocatorRef, domain: core_foundation_sys::string::CFStringRef, code: CFIndex, userInfo: core_foundation_sys::dictionary::CFDictionaryRef) -> CFErrorRef;
 }
 
-#[cfg(not(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+#[cfg(not(any(feature = "OSX_10_14", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos")))]
 fn cferror_from_osstatus(code: core_foundation_sys::base::OSStatus) -> CFError {
     unsafe {
         let error = CFErrorCreate(ptr::null_mut(), core_foundation_sys::error::kCFErrorDomainOSStatus, code as _, ptr::null_mut());


### PR DESCRIPTION
Support for the Apple Vision Pro was added as a tier 3 target with a `targe_os` of `visionos` to rust in https://github.com/rust-lang/rust/pull/121419. Needs https://github.com/rust-lang/libc/pull/3568 to do proper build for the target `aarch64-apple-visionos-sim` or `aarch64-apple-visionos`.

This is basically the same changes as #190 but with another `target_os`.