### PR TITLE
feat(search): add case-insensitive and subject item search options

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -12,6 +12,8 @@ extern "C" {
     pub static kSecMatchLimitAll: CFStringRef;
 
     pub static kSecMatchTrustedOnly: CFStringRef;
+    pub static kSecMatchCaseInsensitive: CFStringRef;
+    pub static kSecMatchSubjectWholeString: CFStringRef; 
 
     pub static kSecReturnData: CFStringRef;
     pub static kSecReturnAttributes: CFStringRef;

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -242,7 +242,7 @@ impl ItemSearchOptions {
         self
     }
     
-    /// Search for an item with the given subject.
+    /// Search for an item with exactly the given subject.
     #[inline(always)]
     pub fn subject(&mut self, subject: &str) -> &mut Self {
         self.subject = Some(CFString::new(subject));


### PR DESCRIPTION
Extend `ItemSearchOptions` with the following options:
- `.subject(&self, &str)` using [`kSecMatchSubjectWholeString`](https://developer.apple.com/documentation/security/ksecmatchsubjectwholestring)
- `.case_insensitive(self, Option<bool>)` using [`kSecMatchCaseInsensitive`](https://developer.apple.com/documentation/security/ksecmatchcaseinsensitive)