### PR TITLE
fix: Exclude macOS-only Keychain symbol for iOS compatibility

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -13,6 +13,7 @@ extern "C" {
 
     pub static kSecMatchTrustedOnly: CFStringRef;
     pub static kSecMatchCaseInsensitive: CFStringRef;
+    #[cfg(target_os = "macos")]
     pub static kSecMatchSubjectWholeString: CFStringRef; 
 
     pub static kSecReturnData: CFStringRef;

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -367,11 +367,14 @@ impl ItemSearchOptions {
                 ));
             }
             
-            if let Some(ref subject) = self.subject {
-                params.push((
-                    CFString::wrap_under_get_rule(kSecMatchSubjectWholeString),
-                    subject.as_CFType(),
-                ));
+            #[cfg(target_os = "macos")]
+            {
+                if let Some(ref subject) = self.subject {
+                    params.push((
+                        CFString::wrap_under_get_rule(kSecMatchSubjectWholeString),
+                        subject.as_CFType(),
+                    ));
+                }
             }
 
             if let Some(ref account) = self.account {


### PR DESCRIPTION
Inclusion of the `kSecMatchSubjectWholeString` symbol when compiling for iOS, which is not supported according to Apple's documentation, is prevented. Conditional compilation directives are added to ensure that builds targeted for iOS do not use macOS exclusive Keychain functionalities.

This adjustment resolves a compilation failure encountered following an update of the 'rust-security-framework' dependency, thereby enhancing the cross-platform compatibility of the SDK.