### PR TITLE
Don't extend from an empty slice.

### DIFF
--- a/security-framework/src/passwords.rs
+++ b/security-framework/src/passwords.rs
@@ -160,7 +160,9 @@ fn get_password_and_release(data: CFTypeRef) -> Result<Vec<u8>> {
         if type_id == CFData::type_id() {
             let val = unsafe { CFData::wrap_under_create_rule(data as CFDataRef) };
             let mut vec = Vec::new();
-            vec.extend_from_slice(val.bytes());
+            if val.len() > 0 {
+                vec.extend_from_slice(val.bytes());
+            }
             return Ok(vec);
         }
         // unexpected: we got a reference to some other type.


### PR DESCRIPTION
Fixes kornelski/rust-security-framework#206.