### PR TITLE
Key agreement via `SecKeyCopyKeyExchangeResult()`

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -68,6 +68,11 @@ extern "C" {
     pub static kSecAttrAccessGroup: CFStringRef;
     pub static kSecAttrAccessGroupToken: CFStringRef;
 
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub static kSecKeyKeyExchangeParameterRequestedSize: CFStringRef;
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub static kSecKeyKeyExchangeParameterSharedInfo: CFStringRef;
+
     pub static kSecAttrAuthenticationType: CFStringRef;
     pub static kSecAttrComment: CFStringRef;
     pub static kSecAttrDescription: CFStringRef;

--- a/security-framework-sys/src/key.rs
+++ b/security-framework-sys/src/key.rs
@@ -29,6 +29,13 @@ extern "C" {
     #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub fn SecKeyCreateRandomKey(parameters: CFDictionaryRef, error: *mut CFErrorRef) -> SecKeyRef;
 
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub fn SecKeyCreateWithData(
+        keyData: CFDataRef,
+        attributes: CFDictionaryRef,
+        error: *mut CFErrorRef,
+    ) -> SecKeyRef;
+
     #[cfg(target_os = "macos")]
     pub fn SecKeyCreateFromData(
         parameters: CFDictionaryRef,

--- a/security-framework-sys/src/key.rs
+++ b/security-framework-sys/src/key.rs
@@ -82,6 +82,15 @@ extern "C" {
         operation: SecKeyOperationType,
         algorithm: SecKeyAlgorithm,
     ) -> core_foundation_sys::base::Boolean;
+
+    #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub fn SecKeyCopyKeyExchangeResult(
+        privateKey: SecKeyRef,
+        algorithm: SecKeyAlgorithm,
+        publicKey: SecKeyRef,
+        parameters: CFDictionaryRef,
+        error: *mut CFErrorRef,
+    ) -> CFDataRef;
 }
 
 #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]

--- a/security-framework/src/key.rs
+++ b/security-framework/src/key.rs
@@ -118,6 +118,15 @@ impl KeyType {
         unsafe { Self(kSecAttrKeyTypeEC) }
     }
 
+    #[inline(always)]
+    #[must_use]
+    pub fn ec_sec_prime_random() -> Self {
+        use security_framework_sys::item::kSecAttrKeyTypeECSECPrimeRandom;
+
+        unsafe { Self(kSecAttrKeyTypeECSECPrimeRandom) }
+    }
+
+
     pub(crate) fn to_str(self) -> CFString {
         unsafe { CFString::wrap_under_get_rule(self.0) }
     }


### PR DESCRIPTION
Added ` SecKeyCopyKeyExchangeResult()` to leverage `Security.framework` for ECDH-type key agreement.