### PR TITLE
Support user-defined generic password options/attributes.

### DIFF
--- a/security-framework/src/passwords.rs
+++ b/security-framework/src/passwords.rs
@@ -27,6 +27,14 @@ pub fn set_generic_password(service: &str, account: &str, password: &[u8]) -> Re
     set_password_internal(&mut options, password)
 }
 
+/// Set a generic password using the given password options.
+/// Creates or updates a keychain entry.
+pub fn set_generic_password_options(
+    password: &[u8],
+    mut options: PasswordOptions) -> Result<()> {
+    set_password_internal(&mut options, password)
+}
+
 /// Get the generic password for the given service and account.  If no matching
 /// keychain entry exists, fails with error code `errSecItemNotFound`.
 pub fn get_generic_password(service: &str, account: &str) -> Result<Vec<u8>> {

--- a/security-framework/src/passwords_options.rs
+++ b/security-framework/src/passwords_options.rs
@@ -1,7 +1,7 @@
 //! Support for password options, to be used with the passwords module
 
 use core_foundation::{string::CFString, base::{CFType, TCFType, CFOptionFlags}, number::CFNumber};
-use security_framework_sys::{keychain::{SecProtocolType, SecAuthenticationType}, access_control::*};
+use security_framework_sys::{access_control::*, item::kSecAttrAccessGroup, keychain::{SecAuthenticationType, SecProtocolType}};
 use security_framework_sys::item::{
     kSecAttrAccessControl, kSecAttrAccount, kSecAttrAuthenticationType, kSecAttrPath, kSecAttrPort, kSecAttrProtocol,
     kSecAttrSecurityDomain, kSecAttrServer, kSecAttrService, kSecClass, kSecClassGenericPassword,
@@ -125,6 +125,14 @@ impl PasswordOptions {
             SecAccessControl::create_with_flags(options.bits())
                 .unwrap()
                 .into_CFType(),
+        ));
+    }
+
+    /// Add access group to the password
+    pub fn set_access_group(&mut self, group: &str) {
+        self.query.push((
+            unsafe { CFString::wrap_under_get_rule(kSecAttrAccessGroup) },
+            CFString::from(group).into_CFType(),
         ));
     }
 }


### PR DESCRIPTION
This is a quick sketch to discuss support for custom attributes/options when creating generic passwords.

The desire is to be able to support more complex use cases such as specifying `kSecAccessControl`, `kSecAccessGroup` etc. for a generic password.

Currently I've added this as an additional `set_generic_password_options()` function so as not to introduce any breaking changes but ultimately I think a builder style API for `PasswordOptions` would be more ergonomic. Perhaps:

```rust
let options = PasswordOptions::builder()
  .service("com.example")
  .account("user-id")
  .password("mock-password")
  .access_control(AccessControlOptions::USER_PRESENCE)
  .access_group("com.example.shared-keychain-group")
  .build()
  .unwrap();  // Panic here as kSecAccessControl and kSecAccessGroup are mutually exclusive?
```

Then we could make the breaking change that `set_generic_password()` just accepts `PasswordOptions` and the password and wouldn't need the additional function if that is acceptable for the next major release.

I notice in #186 there are other people that would also like to be able to use `kSecAccessControl` with `SecItemAdd` so I think it makes sense that we support the other attributes too.

Your thoughts and feedback would be appreciated 🙏 

Closes #219 