### PR TITLE
Add keychain synchronisation and authentication context

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -44,6 +44,10 @@ extern "C" {
     pub static kSecAttrTokenID: CFStringRef;
     #[cfg(any(feature = "OSX_10_12", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecAttrTokenIDSecureEnclave: CFStringRef;
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub static kSecUseAuthenticationContext: CFStringRef;
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub static kSecAttrSynchronizable: CFStringRef;
 
     pub static kSecAttrKeySizeInBits: CFStringRef;
 

--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "security-framework"
 version = "3.1.0"
-authors = ["Steven Fackler <sfackler@gmail.com>", "Kornel <kornel@geekhood.net>"]
+authors = [
+    "Steven Fackler <sfackler@gmail.com>",
+    "Kornel <kornel@geekhood.net>",
+]
 license = "MIT OR Apache-2.0"
 description = "Security.framework bindings for macOS and iOS"
 repository = "https://github.com/kornelski/rust-security-framework"
@@ -24,7 +27,7 @@ log = { version = "0.4.20", optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"
-env_logger = "0.10" # old for MSRV test
+env_logger = "0.10"  # old for MSRV test
 x509-parser = "0.16"
 time = "0.3.23"
 tempfile = "3.12.0"
@@ -34,9 +37,15 @@ default = ["OSX_10_12"]
 alpn = []
 session-tickets = []
 job-bless = []
+sync-keychain = ["OSX_10_13"]
 
 OSX_10_12 = ["security-framework-sys/OSX_10_12"]
-OSX_10_13 = ["OSX_10_12", "security-framework-sys/OSX_10_13", "alpn", "session-tickets"]
+OSX_10_13 = [
+    "OSX_10_12",
+    "security-framework-sys/OSX_10_13",
+    "alpn",
+    "session-tickets",
+]
 OSX_10_14 = ["OSX_10_13", "security-framework-sys/OSX_10_14"]
 OSX_10_15 = ["OSX_10_14", "security-framework-sys/OSX_10_15"]
 


### PR DESCRIPTION
Added the ability to pass an LAContext to the keychain key operations as well as the kSecAttrSynchronizable flag during the creation of keys.