### PR TITLE
Expose simplify dict logic

### DIFF
--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -556,31 +556,7 @@ impl SearchResult {
     #[must_use]
     pub fn simplify_dict(&self) -> Option<HashMap<String, String>> {
         match *self {
-            Self::Dict(ref d) => unsafe {
-                let mut retmap = HashMap::new();
-                let (keys, values) = d.get_keys_and_values();
-                for (k, v) in keys.iter().zip(values.iter()) {
-                    let keycfstr = CFString::wrap_under_get_rule((*k).cast());
-                    let val: String = match CFGetTypeID(*v) {
-                        cfstring if cfstring == CFString::type_id() => {
-                            format!("{}", CFString::wrap_under_get_rule((*v).cast()))
-                        },
-                        cfdata if cfdata == CFData::type_id() => {
-                            let buf = CFData::wrap_under_get_rule((*v).cast());
-                            let mut vec = Vec::new();
-                            vec.extend_from_slice(buf.bytes());
-                            format!("{}", String::from_utf8_lossy(&vec))
-                        }
-                        cfdate if cfdate == CFDate::type_id() => format!(
-                            "{}",
-                            CFString::wrap_under_create_rule(CFCopyDescription(*v))
-                        ),
-                        _ => String::from("unknown"),
-                    };
-                    retmap.insert(format!("{keycfstr}"), val);
-                }
-                Some(retmap)
-            },
+            Self::Dict(ref d) => Some(simplify_dict(d)),
             _ => None,
         }
     }

--- a/security-framework/src/lib.rs
+++ b/security-framework/src/lib.rs
@@ -50,6 +50,7 @@ pub mod secure_transport;
 pub mod trust;
 #[cfg(target_os = "macos")]
 pub mod trust_settings;
+pub mod utils;
 
 #[cfg(target_os = "macos")]
 trait Pkcs12ImportOptionsInternals {

--- a/security-framework/src/utils.rs
+++ b/security-framework/src/utils.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use core_foundation::{base::{CFCopyDescription, CFGetTypeID, TCFType}, data::CFData, date::CFDate, dictionary::CFDictionary, string::CFString};
+
+pub fn simplify_dict(dict: &CFDictionary) -> HashMap<String, String> {
+    unsafe {
+        let mut retmap = HashMap::new();
+        let (keys, values) = dict.get_keys_and_values();
+        for (k, v) in keys.iter().zip(values.iter()) {
+            let keycfstr = CFString::wrap_under_get_rule((*k).cast());
+            let val: String = match CFGetTypeID(*v) {
+                cfstring if cfstring == CFString::type_id() => {
+                    format!("{}", CFString::wrap_under_get_rule((*v).cast()))
+                },
+                cfdata if cfdata == CFData::type_id() => {
+                    let buf = CFData::wrap_under_get_rule((*v).cast());
+                    let mut vec = Vec::new();
+                    vec.extend_from_slice(buf.bytes());
+                    format!("{}", String::from_utf8_lossy(&vec))
+                }
+                cfdate if cfdate == CFDate::type_id() => format!(
+                    "{}",
+                    CFString::wrap_under_create_rule(CFCopyDescription(*v))
+                ),
+                _ => String::from("unknown"),
+            };
+            retmap.insert(format!("{keycfstr}"), val);
+        }
+        retmap
+    }
+}


### PR DESCRIPTION
When we have a `CFDictionary`, it would be great to have a utility to cast it into HashMap for easy programmatic access. The logic is already present in this repository, this PR simply exposes it so that dependents can use it.