### PR TITLE
Enable access control and authentication contexts

### DIFF
--- a/security-framework/Cargo.toml
+++ b/security-framework/Cargo.toml
@@ -64,6 +64,10 @@ name = "find_internet_password"
 [[example]]
 name = "set_internet_password"
 
+[[example]]
+name = "biometric_password"
+required-features = ["OSX_10_13"]
+
 [package.metadata.docs.rs]
 targets = ["x86_64-apple-darwin", "aarch64-apple-ios"]
 features = ["OSX_10_15"]

--- a/security-framework/examples/Info.plist
+++ b/security-framework/examples/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>biometric_password</string>
+	<key>CFBundleIdentifier</key>
+	<string>2TM4K8523U.biometric-test</string>
+	<key>CFBundleName</key>
+	<string>Biometric Password Example</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.13</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>This app uses Face ID to secure password access.</string>
+	<key>NSTouchIDUsageDescription</key>
+	<string>This app uses Touch ID to secure password access.</string>
+</dict>
+</plist>

--- a/security-framework/examples/biometric_password.rs
+++ b/security-framework/examples/biometric_password.rs
@@ -1,0 +1,58 @@
+//! Store and retrieve a password with biometric authentication
+//!
+//! This example demonstrates storing a password that requires Touch ID or Face ID
+//! to access, equivalent to the Swift code in unpass-mac/Unpass/ContentView.swift
+
+use security_framework::access_control::ProtectionMode;
+use security_framework::passwords::{set_generic_password_options, get_generic_password_options};
+use security_framework::passwords_options::{AccessControlOptions, PasswordOptions};
+
+fn main() {
+    let service = "com.example.biometric-test";
+    let account = "testuser";
+    let password = b"secret123";
+
+    // Store password with biometric protection
+    let mut options = PasswordOptions::new_generic_password(service, account);
+    options.set_access_control(
+        ProtectionMode::AccessibleWhenUnlockedThisDeviceOnly,
+        AccessControlOptions::BIOMETRY_ANY
+    );
+
+    match set_generic_password_options(password, options) {
+        Ok(()) => {
+            println!("Password stored with biometric protection for {account}@{service}");
+            println!("Protection: AccessibleWhenUnlockedThisDeviceOnly + BIOMETRY_ANY");
+        }
+        Err(err) => {
+            eprintln!("Could not store password: {err:?}");
+            return;
+        }
+    }
+
+    // Retrieve the password with authentication context
+    #[cfg(feature = "OSX_10_13")]
+    {
+        println!("Attempting to retrieve password...");
+        println!("Note: In a real app, you would create an LAContext from LocalAuthentication framework");
+
+        // For demonstration, we'll show what the code would look like:
+        // let la_context = create_la_context(); // This would come from LocalAuthentication
+        // let la_context_ptr = la_context as *mut std::os::raw::c_void;
+
+        let retrieve_options = PasswordOptions::new_generic_password(service, account);
+        // retrieve_options.set_authentication_context(la_context_ptr);
+
+        // Since we don't have a real LAContext, this will fail with authentication required
+        match get_generic_password_options(retrieve_options) {
+            Ok(retrieved) => {
+                println!("Retrieved password: {:?}", std::str::from_utf8(&retrieved));
+                println!("Password matches: {}", retrieved == password);
+            }
+            Err(err) => {
+                println!("Expected error without authentication context: {err:?}");
+                println!("This demonstrates that biometric protection is working!");
+            }
+        }
+    }
+}

--- a/security-framework/examples/entitlements.plist
+++ b/security-framework/examples/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>2TM4K8523U.*</string>
+    </array>
+    <key>com.apple.security.device.biometry</key>
+    <true/>
+    <key>com.apple.security.personal-information.biometry</key>
+    <true/>
+</dict>
+</plist>

--- a/security-framework/src/passwords.rs
+++ b/security-framework/src/passwords.rs
@@ -49,6 +49,21 @@ pub fn get_generic_password(service: &str, account: &str) -> Result<Vec<u8>> {
     get_password_and_release(ret)
 }
 
+/// Get the generic password using the given password options, including authentication context.
+/// If no matching keychain entry exists, fails with error code `errSecItemNotFound`.
+pub fn get_generic_password_options(mut options: PasswordOptions) -> Result<Vec<u8>> {
+    #[allow(deprecated)]
+    options.query.push((
+        unsafe { CFString::wrap_under_get_rule(kSecReturnData) },
+        CFBoolean::from(true).into_CFType(),
+    ));
+    #[allow(deprecated)]
+    let params = CFDictionary::from_CFType_pairs(&options.query);
+    let mut ret: CFTypeRef = std::ptr::null();
+    cvt(unsafe { SecItemCopyMatching(params.as_concrete_TypeRef(), &mut ret) })?;
+    get_password_and_release(ret)
+}
+
 /// Delete the generic password keychain entry for the given service and account.
 /// If none exists, fails with error code `errSecItemNotFound`.
 pub fn delete_generic_password(service: &str, account: &str) -> Result<()> {

--- a/security-framework/src/passwords_options.rs
+++ b/security-framework/src/passwords_options.rs
@@ -106,6 +106,15 @@ impl PasswordOptions {
         Self { query }
     }
 
+    /// Add access control to the password with protection mode
+    pub fn set_access_control(&mut self, protection: crate::access_control::ProtectionMode, options: AccessControlOptions) {
+        #[allow(deprecated)]
+        self.query.push((
+            unsafe { CFString::wrap_under_get_rule(kSecAttrAccessControl) },
+            SecAccessControl::create_with_protection(Some(protection), options.bits()).unwrap().into_CFType(),
+        ));
+    }
+
     /// Add access control to the password
     pub fn set_access_control_options(&mut self, options: AccessControlOptions) {
         #[allow(deprecated)]
@@ -121,6 +130,17 @@ impl PasswordOptions {
         self.query.push((
             unsafe { CFString::wrap_under_get_rule(kSecAttrAccessGroup) },
             CFString::from(group).into_CFType(),
+        ));
+    }
+
+    /// Add authentication context for biometric authentication
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub fn set_authentication_context(&mut self, context: *mut std::os::raw::c_void) {
+        use security_framework_sys::item::kSecUseAuthenticationContext;
+        #[allow(deprecated)]
+        self.query.push((
+            unsafe { CFString::wrap_under_get_rule(kSecUseAuthenticationContext) },
+            unsafe { CFType::wrap_under_create_rule(context) },
         ));
     }
 }


### PR DESCRIPTION
This enables creating keychain items that require Touch ID/Face ID authentication, equivalent to the Swift SecAccessControlCreateWithFlags API.

This allows things like setting BIOMETRY_ANY on created passwords, adding a public `get_generic_password_options` that allows PasswordOptions to be used for keychain items, and also allowing AccessControl and AuthenticationContext to be set on PasswordOptions.

With some arduous work (an Info.plist and entitlements plist need to be added, and the binary needs to be codesigned with a developer key for which there is a provisioning profile that allows the correct machines and features), I was able to build the included example binary and confirm that it works as expected (it shows a TouchID prompt on my Mac when I save and load the password.)