### PR TITLE
Add a client-constructed access control object to a password item

### DIFF
--- a/security-framework/src/passwords_options.rs
+++ b/security-framework/src/passwords_options.rs
@@ -114,6 +114,13 @@ impl PasswordOptions {
         }
     }
 
+    /// Add access control to the password
+    pub fn set_access_control(&mut self, access_control: SecAccessControl) {
+        unsafe {
+            self.push_query(kSecAttrAccessControl, access_control);
+        }
+    }
+
     /// Add access group to the password
     pub fn set_access_group(&mut self, group: &str) {
         unsafe {


### PR DESCRIPTION
Fixes kornelski/rust-security-framework#226.

This fix has been tested on both macOS and iOS from apps that have provisioning profiles (which are the only ones that can set access control objects).

This signature allows setting both the protection mode and the access options on the item, as opposed to the existing set_access_control_options which doesn't allow specifying protection mode.