### PR TITLE
Add ItemSearchOptions support for skipping authenticated items.

### DIFF
--- a/security-framework-sys/src/item.rs
+++ b/security-framework-sys/src/item.rs
@@ -47,6 +47,10 @@ extern "C" {
     #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecUseAuthenticationContext: CFStringRef;
     #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub static kSecUseAuthenticationUI: CFStringRef;
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub static kSecUseAuthenticationUISkip: CFStringRef;
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     pub static kSecAttrSynchronizable: CFStringRef;
 
     pub static kSecAttrKeySizeInBits: CFStringRef;

--- a/security-framework/src/item.rs
+++ b/security-framework/src/item.rs
@@ -146,6 +146,8 @@ pub struct ItemSearchOptions {
     app_label: Option<CFData>,
     #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
     authentication_context: Option<CFType>,
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    skip_authenticated_items: bool,
 }
 
 #[cfg(target_os = "macos")]
@@ -309,6 +311,14 @@ impl ItemSearchOptions {
         self
     }
 
+    /// Whether to skip items in the search that require authentication (default false)
+    #[inline(always)]
+    #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    pub fn skip_authenticated_items(&mut self, do_skip: bool) -> &mut Self {
+        self.skip_authenticated_items = do_skip;
+        self
+    }
+
     /// Populates a `CFDictionary` to be passed to `update_item` or `delete_item`.
     // CFDictionary should not be exposed in public Rust APIs.
     #[inline]
@@ -405,6 +415,11 @@ impl ItemSearchOptions {
             #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
             if let Some(ref authentication_context) = self.authentication_context {
                 params.add(&kSecUseAuthenticationContext.to_void(), &authentication_context.to_void());
+            }
+
+            #[cfg(any(feature = "OSX_10_13", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+            if self.skip_authenticated_items {
+                params.add(&kSecUseAuthenticationUI.to_void(), &kSecUseAuthenticationUISkip.to_void());
             }
 
             params.to_immutable()


### PR DESCRIPTION
Fixes kornelski/rust-security-framework#231.

This touches security-framework-sys (two new constants) as well as the security-framework itself.