### PR TITLE
Add more password options.

### DIFF
--- a/security-framework/src/passwords_options.rs
+++ b/security-framework/src/passwords_options.rs
@@ -5,15 +5,20 @@
 
 use crate::access_control::SecAccessControl;
 use core_foundation::base::{CFOptionFlags, CFType, TCFType};
+#[allow(unused_imports)]
+use core_foundation::boolean::CFBoolean;    // only used (currently) in code for OSX_10_15
 use core_foundation::dictionary::CFDictionary;
 use core_foundation::number::CFNumber;
 use core_foundation::string::{CFString, CFStringRef};
 use security_framework_sys::access_control::*;
 use security_framework_sys::item::{
     kSecAttrAccessControl, kSecAttrAccessGroup, kSecAttrAccount, kSecAttrAuthenticationType,
+    kSecAttrComment, kSecAttrDescription, kSecAttrLabel,
     kSecAttrPath, kSecAttrPort, kSecAttrProtocol, kSecAttrSecurityDomain, kSecAttrServer,
     kSecAttrService, kSecClass, kSecClassGenericPassword, kSecClassInternetPassword,
 };
+#[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+use security_framework_sys::item::kSecUseDataProtectionKeychain;
 use security_framework_sys::keychain::{SecAuthenticationType, SecProtocolType};
 
 /// `PasswordOptions` constructor
@@ -127,6 +132,35 @@ impl PasswordOptions {
     pub fn set_access_group(&mut self, group: &str) {
         unsafe {
             self.push_query(kSecAttrAccessGroup, CFString::from(group));
+        }
+    }
+
+    /// Set the comment on the password
+    pub fn set_comment(&mut self, comment: &str) {
+        unsafe {
+            self.push_query(kSecAttrComment, CFString::from(comment));
+        }
+    }
+
+    /// Add a description to the password
+    pub fn set_description(&mut self, description: &str) {
+        unsafe {
+            self.push_query(kSecAttrDescription, CFString::from(description));
+        }
+    }
+
+    /// Add a label to the password
+    pub fn set_label(&mut self, label: &str) {
+        unsafe {
+            self.push_query(kSecAttrLabel, CFString::from(label));
+        }
+    }
+
+    #[cfg(any(feature = "OSX_10_15", target_os = "ios", target_os = "tvos", target_os = "watchos", target_os = "visionos"))]
+    /// Use the data protection keychain (always true except on macOS)
+    pub fn use_protected_keychain(&mut self) {
+        unsafe {
+            self.push_query(kSecUseDataProtectionKeychain, CFBoolean::from(true));
         }
     }
 


### PR DESCRIPTION
Allows setting the desired comment, description, and label for the item.

Allows for selecting the protected data store on macOS so protected features can be used.

Fixes kornelski/rust-security-framework#237.