### PR TITLE
Add a default mode to SecAccessControl::create_with_protection

### DIFF
--- a/security-framework/src/access_control.rs
+++ b/security-framework/src/access_control.rs
@@ -12,7 +12,7 @@ use security_framework_sys::access_control::{
 };
 use security_framework_sys::base::{errSecParam, SecAccessControlRef};
 use std::fmt;
-use std::ptr::{self, null};
+use std::ptr;
 
 declare_TCFType! {
     /// A type representing sec access control settings.
@@ -62,11 +62,13 @@ impl SecAccessControl {
                 ProtectionMode::AccessibleAfterFirstUnlockThisDeviceOnly => unsafe { CFString::wrap_under_get_rule(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly) },
                 ProtectionMode::AccessibleAfterFirstUnlock => unsafe { CFString::wrap_under_get_rule(kSecAttrAccessibleAfterFirstUnlock) },
             }
+        }).unwrap_or_else(|| {
+            unsafe { CFString::wrap_under_get_rule(kSecAttrAccessibleWhenUnlocked) }
         });
         unsafe {
             let access_control = SecAccessControlCreateWithFlags(
                 kCFAllocatorDefault,
-                protection_val.map(|v| v.as_CFTypeRef()).unwrap_or(null()),
+                protection_val.as_CFTypeRef(),
                 flags,
                 ptr::null_mut(),
             );


### PR DESCRIPTION
If you invoke SecAccessControl::create_with_protection and pass a null for the optional protection parameter, we now use `ProtectionMode::AccessibleWhenUnlocked`.

Fixes kornelski/rust-security-framework#228.